### PR TITLE
bug in fact_regular_users: ubuntu user is set

### DIFF
--- a/roles/fact_regular_users/tasks/main.yml
+++ b/roles/fact_regular_users/tasks/main.yml
@@ -30,6 +30,6 @@
 - name: set fact regular_users
   set_fact:
     fact_regular_users: "{{ getent_passwd|dict2items|to_json|from_json|
-    json_query('[?to_number(value[1]) >`999` && starts_with(value[4], `/home/`) 
+    json_query('[?to_number(value[1]) >`1000` && starts_with(value[4], `/home/`) 
     ].{user: key, userid: to_number(value[1]), groupid: to_number(value[2]), 
     description: value[3], home: value[4], shell: value[5]}') }}"

--- a/roles/fact_regular_users/tasks/main.yml
+++ b/roles/fact_regular_users/tasks/main.yml
@@ -30,6 +30,6 @@
 - name: set fact regular_users
   set_fact:
     fact_regular_users: "{{ getent_passwd|dict2items|to_json|from_json|
-    json_query('[?to_number(value[1]) >`999` && starts_with(value[4], `/home/`) 
+    json_query('[?to_number(value[1]) >`999` && starts_with(value[4], `/home/`) && key!=`ubuntu`
     ].{user: key, userid: to_number(value[1]), groupid: to_number(value[2]), 
     description: value[3], home: value[4], shell: value[5]}') }}"

--- a/roles/fact_regular_users/tasks/main.yml
+++ b/roles/fact_regular_users/tasks/main.yml
@@ -30,6 +30,6 @@
 - name: set fact regular_users
   set_fact:
     fact_regular_users: "{{ getent_passwd|dict2items|to_json|from_json|
-    json_query('[?to_number(value[1]) >`1000` && starts_with(value[4], `/home/`) 
+    json_query('[?to_number(value[1]) >`999` && starts_with(value[4], `/home/`) 
     ].{user: key, userid: to_number(value[1]), groupid: to_number(value[2]), 
     description: value[3], home: value[4], shell: value[5]}') }}"


### PR DESCRIPTION
By excluding id 1000 which is by default given to the `ubuntu` user, it is skipped and will no longer fail playbooks that install something on a per-user basis that use this role.