### PR TITLE
new role: desktop_file

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ SURF ResearchCloud.
 ## Roles
 - [camunda-modeler](roles/camunda-modeler.md)
 - [camunda-server](roles/camunda-server.md)
+- [desktop-file](roles/desktop_file.md)
 - [docker](roles/docker.md)
 - [fact_regular_users](roles/fact_regular_users.md)
 - [irods_guisync](roles/irods_guisync.md)

--- a/docs/roles/desktop_file.md
+++ b/docs/roles/desktop_file.md
@@ -1,0 +1,35 @@
+# Role <name>
+[back to index](../index.md#Roles)
+
+## Summary
+Explain the use case for this role in one or two sentences. 
+This role can be used to easily install desktop items through the xdg-utils package.
+
+
+## Requires
+An environment that suports xdg-utils.
+
+## Description
+Elaborate on the purpose and functions of the role
+
+## Variables
+
+### Required variables
+* `app_name`: String. The name of your application for which to install a desktop item.
+* `sizes`: List of integers. The different pixel count sizes of your icons. Common sizes are 16, 22, 32, 48, 64 and 128.
+
+### Required files
+While not variables, the below files are assumed to exist in your playbook or roles `/files` or `/templates` folder.
+* `app_name.desktop` file: The desktop file/template to use. Strict name convention based on the `app_name` required variable.
+* `app_name-size-x-size.png` files: One file for each of your sizes of your icon. At least every `size` in the required variable `sizes` must have one representitive file. Strict name convention based on the `app_name` and `sizes` required variables.
+
+### Optional variables
+* `modules`: List. If defined, a desktop item is installed for each of the modules in the list. This is used when your application needs several desktop items. All the modules will share the same icon.
+
+## See also
+Are there any other related roles? Add a link here.
+
+## History
+2022 Written by Sytse Groenwold
+
+[back to index](../index.md#Roles)

--- a/docs/roles/desktop_file.md
+++ b/docs/roles/desktop_file.md
@@ -1,4 +1,4 @@
-# Role <name>
+# Role desktop_file
 [back to index](../index.md#Roles)
 
 ## Summary
@@ -10,6 +10,48 @@ This role can be used to easily install desktop items through the xdg-utils pack
 An environment that suports xdg-utils.
 
 ## Description
+The purpose of this role is to make the code to install desktop file menu items through xdg-utils reusable.
+This role cannot be a role on itself, due to the requirement of icon files. It has to be called from inside another role that holds the icon files in their respective `files` or `templates` folder. See below example:
+
+```
+# File structure of using this role
+
+researchcloud-items > roles
+└─── application_role
+│   └───files
+│       │   app_name-XX-x-XX.png
+│       templates
+│       │   app_name.desktop.j2
+|       tasks
+│       │   main.yml
+│   
+└─── desktop_file
+    │   ...
+```
+
+The actual role can be called and passed variables as follows:
+
+```
+#researchcloud-items > roles > application_role > tasks > main.yml
+
+[...]
+- name: Create desktop menu items through role
+  include_role:
+    name: desktop_file
+  vars:
+    app_name: <app_name>
+    sizes:
+      - <size1 int>
+      - <size2 int>
+      ...
+    modules:
+      - <desktop item>
+      - <desktop item>
+    var_required_for_app_name.desktop.j2: value
+    ...
+[...]
+```
+
 Elaborate on the purpose and functions of the role
 
 ## Variables
@@ -19,12 +61,13 @@ Elaborate on the purpose and functions of the role
 * `sizes`: List of integers. The different pixel count sizes of your icons. Common sizes are 16, 22, 32, 48, 64 and 128.
 
 ### Required files
-While not variables, the below files are assumed to exist in your playbook or roles `/files` or `/templates` folder.
+While not variables, the below files are assumed to exist in your playbook or roles `/files` or `/templates` folder. See the file structure example above.
 * `app_name.desktop` file: The desktop file/template to use. Strict name convention based on the `app_name` required variable.
 * `app_name-size-x-size.png` files: One file for each of your sizes of your icon. At least every `size` in the required variable `sizes` must have one representitive file. Strict name convention based on the `app_name` and `sizes` required variables.
 
 ### Optional variables
 * `modules`: List. If defined, a desktop item is installed for each of the modules in the list. This is used when your application needs several desktop items. All the modules will share the same icon.
+* If your `app_name.desktop` file is a Jinja2 template that holds variables, ensure that those variables are passed to this role as well.
 
 ## See also
 Are there any other related roles? Add a link here.

--- a/roles/desktop_file/defaults/main.yml
+++ b/roles/desktop_file/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+desktop: true
+menu: true
+login: false
+...

--- a/roles/desktop_file/defaults/main.yml
+++ b/roles/desktop_file/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-desktop: true
+# these variables can be used to define whether the icon should also be created as a shortcut on the desktop and if the application should start at launch.
 menu: true
+desktop: false
 login: false
 ...

--- a/roles/desktop_file/tasks/main.yml
+++ b/roles/desktop_file/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+- name: Check if required variables are present
+  when: (app_name is not defined) and (sizes is not defined)
+
+- name: install xdg utilities
+  package: 
+    name: "xdg-utils"
+    state: present
+
+- name: copy icon files to /tmp 
+  copy:
+    src: "{{ app_name }}-{{ item }}x{{ item }}.png"
+    dest: "/tmp/{{ app_name }}-{{ item }}x{{ item }}.png"
+    mode: 0644
+  with_items: "{{ sizes }}"
+
+- name: install icons as xdg resource
+  command: "xdg-icon-resource install --novendor --context apps --size {{ item }} /tmp/{{ app_name }}-{{ item }}x{{ item }}.png {{ app_name }}"
+  with_items: "{{ sizes }}"
+
+- name: copy desktop launcher file to /tmp
+  template:
+    src: "{{ app_name }}.desktop.j2"
+    dest: "/tmp/{{ app_name }}.desktop"
+    mode: 0644
+
+- name: install launcher in system-wide desktop menu
+  when: modules is not defined
+  command: "xdg-desktop-menu install --novendor /tmp/{{ app_name }}.desktop"
+
+- name: Install launcher in system-wide desktop menu for multiple modules
+  when: modules is defined
+  command: "xdg-desktop-menu install --novendor /tmp/{{ app_name }}.desktop"
+  with_items: "{{ modules }}"
+
+...
+# FROM  ASREVIEW
+
+# - name: Copy icon for application shortcut
+#   copy:
+#     src: asreview_icon_64px.png
+#     dest: /usr/share/pixmaps/asreview.png
+#     mode: 644
+
+# - name: Create application shortcuts
+#   copy:
+#     src: asreview.desktop
+#     dest: "{{ item }}"
+#     mode: 644
+#   with_items:
+#     - /usr/share/applications #Application menu item
+#     - /etc/xdg/autostart/     #Launch at start


### PR DESCRIPTION
An idea for a role so we can reuse our code written to install desktop file menu items through xdg-utils.