### PR TITLE
bug role desktop_file: directory does not exist

### DIFF
--- a/roles/desktop_file/tasks/main.yml
+++ b/roles/desktop_file/tasks/main.yml
@@ -3,6 +3,11 @@
   when: (app_name is not defined) and (sizes is not defined)
   meta: end_play
 
+- name: Preventing bug - Ensure directory exists
+  file:
+    path: /usr/share/desktop-directories/
+    state: directory
+
 - name: Install xdg utilities
   package: 
     name: "xdg-utils"


### PR DESCRIPTION
During development of the anaconda role, a bug failed the RSC workspace deployment. This happens because the `/usr/share/desktop-directories/` folder does not exist and is not created automatically by xdg-utils. This simple addition of ensuring the folder exists, solved the issue and thus it is added to the main branch, preventing it popping up in the future in other new roles.