### PR TITLE
Ansible linting

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,3 @@
+profile: production
+exclude_paths:
+  - docs

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,6 @@
+# Using this file instead of "skip_list" in .ansible-list is recommended, as "skip_list" will completely suppress all warnings.
+# By contrast, exceptions listed in this file will be printed in the linter output as "ignored".
+
+# Ignore rules in specific files as follows:
+# playbooks/transferuser.yml yaml[empty-lines]
+


### PR DESCRIPTION
It may be a good idea to start using `ansible-lint` to improve code quality and readability, and impose a uniform style on our roles and playbooks. The default rules enabled for the linter tool are considered best practice for writing Ansible code -- they are used for Ansible Galaxy collections, and also for other UU projects (Yoda). You can have a look at the full default rule list here: https://ansible.readthedocs.io/projects/lint/rules/

However, I don't want to impose any rules on this project that anyone considers counterproductive or too strict. If anyone feels like the default ruleset is too restrictive, please let me know!

This PR just adds a simple configuration file for `ansible-lint`. It currently enables the default, and strictest, `production` profile. That means that all the linter rules are enabled. [Other profiles](https://ansible.readthedocs.io/projects/lint/profiles/) are just subsets of the full rulelist. This PR doesn't yet enable a Github Action. I'm adding the config file mostly to make it a bit easier to use the linter locally, and so we can discuss how exactly we want to configure it.

Below I describe what steps I suggest taking towards integrating linting in this repo. Please let met know whether you think this is a good idea!

## Linter results for the current codebase

The bad news is that running the linter on the current codebase spits out a lot of errors:

```
                          Rule Violation Summary                           
 count tag                           profile    rule associated tags       
     6 command-instead-of-shell      basic      command-shell, idiom       
     9 deprecated-module             basic      deprecations               
    16 jinja[spacing]                basic      formatting (warning)       
     2 no-free-form                  basic      syntax, risk               
    14 role-name                     basic      deprecations, metadata     
    15 schema[meta]                  basic      core                       
     4 schema[playbook]              basic      core                       
     1 schema[tasks]                 basic      core                       
     1 name[missing]                 basic      idiom                      
    14 var-naming[no-role-prefix]    basic      idiom                      
     2 yaml[colons]                  basic      formatting, yaml           
    49 yaml[comments]                basic      formatting, yaml           
    42 yaml[empty-lines]             basic      formatting, yaml           
     2 yaml[hyphens]                 basic      formatting, yaml           
    36 yaml[indentation]             basic      formatting, yaml           
     3 yaml[line-length]             basic      formatting, yaml           
     1 yaml[new-line-at-end-of-file] basic      formatting, yaml           
    63 yaml[octal-values]            basic      formatting, yaml           
   117 yaml[trailing-spaces]         basic      formatting, yaml           
    26 yaml[truthy]                  basic      formatting, yaml           
   189 name[casing]                  moderate   idiom                      
     2 latest[git]                   safety     idempotency                
    11 risky-file-permissions        safety     unpredictability           
    32 no-changed-when               shared     command-shell, idempotency 
   244 fqcn[action-core]             production formatting                 
     8 fqcn[action]                  production formatting    
```

As you can see, most of the errors result from the `basic` profile and concern things like whitespace, tabbing, variable casing, etc. However, there are also a few more complicated issues.

To get an indication of what the code would look like if we adhered to all the rules, you can have a look at [this branch](https://github.com/dometto/researchcloud-items/commit/1b92f271c4a258336c5a0471e9332e38bb39f5fa).

## Fixing current issues

The good news is that we can use `ansible-linter --fix` to auto-fix everything the linter complains about. However, this results in a very large changset. So instead of running `ansible-linter --fix` and opening one huge PR, I suggest that I work my way through the different kinds of failures incrementally. For instance, `ansible-linter --fix yaml` will fix all the yaml formatting issues. I can open a PR with the result of that command, do a sanity check, and continue.

Eventually, we will reach issues (raised by the stricter `shared`, `safety`, and `production` profiles) that might require a bit more thought and review to fix.

## Enabling a CI Action

I suggest we enable a GithubAction for `ansible-lint` once all the current code passes the linter, with whatever ruleset we feel comfortable. From that point, any code that is committed to this repository should pass the linter, or it will break the build. :)

Note that you can use `ansible-linter --fix` as part of your development flow, so you don't have to remember to stick by all the rules yourself when starting to work on a new component, or when editing an old one.