### PR TITLE
Lint python workbench

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,9 @@
+---
+profile: basic
+exclude_paths:
+  - docs
+  - .github
+  - molecule/ext # since this is a subtree, linting should be taken care of upstream
+skip_list:
+  - role-name
+  - var-naming

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,6 @@
+# Using this file instead of "skip_list" in .ansible-list is recommended, as "skip_list" will completely suppress all warnings.
+# By contrast, exceptions listed in this file will be printed in the linter output as "ignored".
+
+# Ignore rules in specific files as follows:
+# playbooks/transferuser.yml yaml[empty-lines]
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+molecule/ext/molecule-src/requirements.yml
+molecule/ext/molecule-src/.ansible-lint
+molecule/ext/molecule-src/.github
+molecule/ext/molecule-src/README.md

--- a/molecule/ext/molecule-src/.github/workflows/ansible-lint.yml
+++ b/molecule/ext/molecule-src/.github/workflows/ansible-lint.yml
@@ -1,0 +1,15 @@
+---
+name: Ansible Lint
+on:
+  push:
+  pull_request:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Ansible Lint
+    steps:
+      # Important: This sets up your GITHUB_WORKSPACE environment variable
+      - uses: actions/checkout@v3
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@v6.20.3

--- a/molecule/ext/molecule-src/converge.yml
+++ b/molecule/ext/molecule-src/converge.yml
@@ -3,19 +3,19 @@
   hosts: all
   gather_facts: false
   tasks:
-
     - name: Debug -- list all components to be executed
       ansible.builtin.debug:
         msg: "{{ item.name }}"
       with_items: "{{ lookup('env', 'components') }}"
 
     - name: Test the component by executing it using ansible on the workspace
-      ansible.builtin.command: ansible-playbook --connection=local -v -b {{ remote_plugin.arguments }} --extra-vars='{{ remote_plugin.parameters }}' /rsc/plugins/{{ item.name }}/{{ item.path }}
+      ansible.builtin.command: ansible-playbook -c local -v -b {{ remote_plugin.arguments }} --extra-vars='{{ remote_plugin.parameters }}' /rsc/plugins/{{
+        item.name }}/{{ item.path }}
       register: ansible_on_workspace
       changed_when: "'changed=0' not in ansible_on_workspace.stdout_lines[-1]"
       vars:
         remote_plugin:
-          script_type: 'Ansible PlayBook'
-          arguments: "-i 127.0.0.1, --skip-tags {{ ansible_skip_tags | join(',') }}"
+          script_type: Ansible PlayBook
+          arguments: -i 127.0.0.1, --skip-tags {{ ansible_skip_tags | join(',') }}
           parameters: "{{ item.parameters | default('{}') }}"
       with_items: "{{ lookup('env', 'components') }}"

--- a/molecule/ext/molecule-src/default.env.yml
+++ b/molecule/ext/molecule-src/default.env.yml
@@ -2,6 +2,6 @@
 # Default Molecule .env.yml file
 # NOTE: to make molecule use this file, place it in the root of your project (or from whichever directory you are calling 'molecule'), and rename it to .env.yml
 PLAYBOOK_DIR: ../../../ # Relative to the default molecule.yml (molecule/ext/molecule-src/molecule.yml)
-ANSIBLE_VERBOSITY: '2'
-ANSIBLE_ROLES_PATH: ../../roles # Relative to your scenario (e.g. molecule/role-foo/..) 
+ANSIBLE_VERBOSITY: "2"
+ANSIBLE_ROLES_PATH: ../../roles # Relative to your scenario (e.g. molecule/role-foo/..)
 REQUIREMENTS_FILE: requirements.txt

--- a/molecule/ext/molecule-src/prepare.yml
+++ b/molecule/ext/molecule-src/prepare.yml
@@ -3,24 +3,24 @@
   hosts: all
   gather_facts: true
   tasks:
-
     - name: Clone git component
       when: item.git is defined
       ansible.builtin.git:
-          repo: "{{ item.git }}"
-          dest: "/rsc/plugins/{{ item.name }}/"
-          refspec: "{{ item.refspec | default(omit) }}"
+        repo: "{{ item.git }}"
+        dest: /rsc/plugins/{{ item.name }}/
+        refspec: "{{ item.refspec | default(omit) }}"
       with_items: "{{ lookup('env', 'components') }}"
+      tags: skip_ansible_lint # linter complains about idempotence of git module
 
     - name: Copy local component
       when: item.git is not defined
       ansible.posix.synchronize:
         src: "{{ item.dir | default(lookup('env', 'PLAYBOOK_DIR')) }}/"
-        dest: "/rsc/plugins/{{ item.name }}/"
+        dest: /rsc/plugins/{{ item.name }}/
         archive: false
         recursive: true
         rsync_opts:
-          - '--exclude=".*"'
+          - --exclude=".*"
         ssh_connection_multiplexing: true
       with_items: "{{ lookup('env', 'components') }}"
 

--- a/molecule/ext/molecule-src/requirements.yml
+++ b/molecule/ext/molecule-src/requirements.yml
@@ -1,0 +1,5 @@
+---
+# This file is just to specify requirements for running the liter on the SRC-Molecule repository.
+collections:
+  - name: ansible.posix
+

--- a/molecule/playbook-python-workbench/molecule.yml
+++ b/molecule/playbook-python-workbench/molecule.yml
@@ -12,5 +12,5 @@ provisioner:
   name: ansible
   env:
     components:
-      - name: 'python-workbench'
-        path: 'python-workbench.yml'
+      - name: python-workbench
+        path: python-workbench.yml

--- a/molecule/playbook-security_updates/molecule.yml
+++ b/molecule/playbook-security_updates/molecule.yml
@@ -16,6 +16,6 @@ provisioner:
       - name: security_updates
         path: security_updates.yml
         parameters:
-          security_updates_firstrun: 'true'
-          security_updates_periodic: 'true'
+          security_updates_firstrun: "true"
+          security_updates_periodic: "true"
           security_updates_delay_time: 15

--- a/molecule/playbook-security_updates/verify.yml
+++ b/molecule/playbook-security_updates/verify.yml
@@ -4,13 +4,12 @@
   gather_facts: false
   tasks:
     - name: Turn off apt timers (active by default on the image)
-      ansible.builtin.command: "{{ item }}"
-      with_items:
-        - systemctl stop apt-daily.timer apt-daily-upgrade.timer
-        - systemctl disable apt-daily.timer apt-daily-upgrade.timer
+      ansible.builtin.systemd:
+        name: apt-daily-upgrade.timer
+        state: stopped
 
     - name: List bootstrap timer
-      ansible.builtin.command: "systemctl list-timers upgrade-bootstrap"
+      ansible.builtin.shell: echo `systemctl list-timers upgrade-bootstrap`
       register: bootstrap_timer
       changed_when: false
 
@@ -20,10 +19,12 @@
           - '"upgrade-bootstrap.service" in bootstrap_timer.stdout'
 
     - name: Run the bootstrap service
-      ansible.builtin.command: "systemctl start upgrade-bootstrap"
+      ansible.builtin.systemd:
+        name: upgrade-bootstrap
+        state: started
 
     - name: List apt timers
-      ansible.builtin.command: "systemctl list-timers *apt*"
+      ansible.builtin.shell: echo `systemctl list-timers *apt*`
       register: apt_timers
       changed_when: false
 
@@ -33,7 +34,7 @@
           - '"2 timers listed" in apt_timers.stdout'
 
     - name: List bootstrap timer
-      ansible.builtin.command: "systemctl list-timers upgrade-bootstrap"
+      ansible.builtin.shell: echo `systemctl list-timers upgrade-bootstrap`
       register: bootstrap_timer
       changed_when: false
 

--- a/molecule/role-default_group/verify.yml
+++ b/molecule/role-default_group/verify.yml
@@ -6,7 +6,7 @@
     - name: Create test user
       ansible.builtin.command: /usr/sbin/adduser --disabled-password --gecos "" testuser2
       register: adduser
-      changed_when: 'adduser.rc == 0'
+      changed_when: adduser.rc == 0
     - name: List testuser groups
       ansible.builtin.command: groups testuser
       changed_when: false
@@ -22,7 +22,7 @@
     - name: Find EXTRA_GROUPS
       register: extra_groups
       changed_when: false
-      command: "grep EXTRA_GROUPS= /etc/adduser.conf"
+      command: grep EXTRA_GROUPS= /etc/adduser.conf
 
     - name: Debug
       ansible.builtin.debug:
@@ -42,4 +42,4 @@
         that:
           - 'list_groups_newuser.stdout == "testuser2 : testuser2 testgroup1 testgroup2"'
           - 'list_groups_olduser.stdout == "testuser : testuser testgroup1 testgroup2"'
-          - 'list_gids_newuser.stdout == "1004 5000 5001"' # 1004 is the gid for testuser2 as testuser1 has 1001, and sudoers and fuse have 1002 and 1003 
+          - list_gids_newuser.stdout == "1004 5000 5001" # 1004 is the gid for testuser2 as testuser1 has 1001, and sudoers and fuse have 1002 and 1003

--- a/molecule/role-fact_regular_user/converge.yml
+++ b/molecule/role-fact_regular_user/converge.yml
@@ -3,6 +3,6 @@
   hosts: all
   gather_facts: false
   tasks:
-      - name: Testing role fact_regular_users
-        ansible.builtin.include_role:
-          name: fact_regular_users
+    - name: Testing role fact_regular_users
+      ansible.builtin.include_role:
+        name: fact_regular_users

--- a/molecule/role-fact_regular_user/molecule.yml
+++ b/molecule/role-fact_regular_user/molecule.yml
@@ -3,4 +3,3 @@ provisioner:
   name: ansible
   playbooks:
     converge: ./converge.yml
-  

--- a/molecule/role-set_gid/converge.yml
+++ b/molecule/role-set_gid/converge.yml
@@ -13,5 +13,5 @@
       ansible.builtin.include_role:
         name: set_gid
       vars:
-        set_gid_paths: '/shared, /home/testuser/shared,/scratch'
-        set_gid_groupname: 'testgroup'
+        set_gid_paths: /shared, /home/testuser/shared,/scratch
+        set_gid_groupname: testgroup

--- a/molecule/role-set_gid/verify.yml
+++ b/molecule/role-set_gid/verify.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   tasks:
     - name: List shared folders
-      ansible.builtin.command: "ls -l -d /shared"
+      ansible.builtin.command: ls -l -d /shared
       register: list_dir1
       changed_when: false
     - name: Debug
@@ -12,7 +12,7 @@
         msg: "{{ list_dir1.stdout }}"
 
     - name: List shared folders
-      ansible.builtin.command: "ls -l -d /home/testuser/shared"
+      ansible.builtin.command: ls -l -d /home/testuser/shared
       register: list_dir2
       changed_when: false
     - name: Debug
@@ -20,7 +20,7 @@
         msg: "{{ list_dir2.stdout }}"
 
     - name: List shared folders
-      ansible.builtin.command: "ls -l -d /scratch"
+      ansible.builtin.command: ls -l -d /scratch
       register: list_dir3
       changed_when: false
     - name: Debug

--- a/playbooks/python-workbench.yml
+++ b/playbooks/python-workbench.yml
@@ -2,7 +2,7 @@
 - name: Install Python environment management tools
   hosts: localhost
   gather_facts: true
-  
+
   roles:
     - python
     - pyenv
@@ -10,6 +10,6 @@
     - role: userspace_applications
       vars:
         list_userspace_applications:
-          - 05-python-3.9.9
+          - "05-python-3.9.9"
           - 10-python-poetry
           - 999ready

--- a/playbooks/roles/pyenv/meta/main.yml
+++ b/playbooks/roles/pyenv/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 
 dependencies:
-- runonce
+  - role: runonce

--- a/playbooks/roles/pyenv/tasks/main.yml
+++ b/playbooks/roles/pyenv/tasks/main.yml
@@ -1,48 +1,46 @@
 ---
-
-- name: install pyenv dependencies, yum package manager
+- name: Install pyenv dependencies, yum package manager
   package:
     name: "{{ item }}"
     state: present
   with_items:
-    - "zlib-devel"
-    - "bzip2"
-    - "bzip2-devel"
-    - "readline-devel"
-    - "sqlite"
-    - "sqlite-devel"
-    - "openssl-devel"
-    - "xz"
-    - "xz-devel"
-    - "libffi-devel"
+    - zlib-devel
+    - bzip2
+    - bzip2-devel
+    - readline-devel
+    - sqlite
+    - sqlite-devel
+    - openssl-devel
+    - xz
+    - xz-devel
+    - libffi-devel
   when: ansible_pkg_mgr == 'yum'
 
-- name: install pyenv dependencies, apt package manager
+- name: Install pyenv dependencies, apt package manager
   package:
-    name: "{{item}}"
+    name: "{{ item }}"
     state: present
   with_items:
-    - "build-essential"
-    - "libssl-dev"
-    - "zlib1g-dev"
-    - "libbz2-dev"
-    - "libreadline-dev"
-    - "libsqlite3-dev"
-    - "wget"
-    - "curl"
-    - "llvm"
-    - "libncurses5-dev"
-    - "libncursesw5-dev"
-    - "xz-utils"
-    - "tk-dev"
-    - "libffi-dev"
-    - "liblzma-dev"
-    - "python-openssl"
+    - build-essential
+    - libssl-dev
+    - zlib1g-dev
+    - libbz2-dev
+    - libreadline-dev
+    - libsqlite3-dev
+    - wget
+    - curl
+    - llvm
+    - libncurses5-dev
+    - libncursesw5-dev
+    - xz-utils
+    - tk-dev
+    - libffi-dev
+    - liblzma-dev
+    - python-openssl
   when: ansible_pkg_mgr == 'apt'
 
-- name: add pyenv install to runonce config
+- name: Add pyenv install to runonce config
   copy:
-    src: "pyenv-install.sh"
-    dest: "/etc/runonce.d/01_pyenv-install.sh"
-    mode: 0755
-
+    src: pyenv-install.sh
+    dest: /etc/runonce.d/01_pyenv-install.sh
+    mode: "0755"

--- a/playbooks/roles/python/meta/main.yml
+++ b/playbooks/roles/python/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 
 dependencies:
-- runonce
+  - role: runonce

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -1,20 +1,19 @@
 ---
-#- name: ensure symbolic link for python exists and is python3, require Ubuntu20
-#  package:
-#    name: python-is-python3
-#    state: present
+# - name: ensure symbolic link for python exists and is python3, require Ubuntu20
+#   package:
+#     name: python-is-python3
+#     state: present
 
-- name: ensure python3-pip is installed
+- name: Ensure python3-pip is installed
   package:
     name: python3-pip
     state: present
 
 # userspace configuration can be added.
 # below is a test script to serve as an example
-    
+
 # - name: place test file
 #  copy:
 #    src: "test.sh"
 #    dest: "/etc/runonce.d/test.sh"
 #    mode: 0755
-

--- a/playbooks/roles/userspace_applications/meta/main.yml
+++ b/playbooks/roles/userspace_applications/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 
 dependencies:
-- runonce
+  - role: runonce

--- a/playbooks/roles/userspace_applications/tasks/main.yml
+++ b/playbooks/roles/userspace_applications/tasks/main.yml
@@ -1,17 +1,16 @@
 ---
 # userspace-applications
-# 
+#
 # copies scripts (files and/or directories with scripts) to runonce.d for subsequent
 # installation upon first-time logon by a user
 #
-# the playbook must provide the list of files/dirs in an 
-# Ansible variable "list_userspace_applications" 
-#  
+# the playbook must provide the list of files/dirs in an
+# Ansible variable "list_userspace_applications"
+#
 
-- name: copy applications to runonce.d directory
+- name: Copy applications to runonce.d directory
   copy:
     src: "{{ item }}"
-    dest: "/etc/runonce.d"
-    mode: 0755
+    dest: /etc/runonce.d
+    mode: "0755"
   with_items: "{{ list_userspace_applications }}"
-


### PR DESCRIPTION
Now that we have molecule test for at least some playbooks, we can start linting our roles and playbooks without having to be afraid of breaking something (some linter recommendations are not trivial).

This PR:

* updates the molecule/ext/molecule-src subtree to the latest version
* adds the linter config files `.ansible-lint` and `.ansible-lint-ignore`
* lints all the files in the `molecule` subdir
* lints all the files related to `python-workbench.yml`

It does not yet add a github workflow for ansible lint, as this would still result into failures for all other (unlinted) files.