### PR TITLE
Update molecule-src subtree

### DIFF
--- a/molecule/ext/molecule-src/.ansible-lint
+++ b/molecule/ext/molecule-src/.ansible-lint
@@ -1,0 +1,4 @@
+---
+profile: basic
+exclude_paths:
+  - .github

--- a/molecule/ext/molecule-src/.github/workflows/ansible-lint.yml
+++ b/molecule/ext/molecule-src/.github/workflows/ansible-lint.yml
@@ -1,0 +1,15 @@
+---
+name: Ansible Lint
+on:
+  push:
+  pull_request:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Ansible Lint
+    steps:
+      # Important: This sets up your GITHUB_WORKSPACE environment variable
+      - uses: actions/checkout@v3
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@v6.20.3

--- a/molecule/ext/molecule-src/converge.yml
+++ b/molecule/ext/molecule-src/converge.yml
@@ -3,19 +3,19 @@
   hosts: all
   gather_facts: false
   tasks:
-
     - name: Debug -- list all components to be executed
       ansible.builtin.debug:
         msg: "{{ item.name }}"
       with_items: "{{ lookup('env', 'components') }}"
 
     - name: Test the component by executing it using ansible on the workspace
-      ansible.builtin.command: ansible-playbook --connection=local -v -b {{ remote_plugin.arguments }} --extra-vars='{{ remote_plugin.parameters }}' /rsc/plugins/{{ item.name }}/{{ item.path }}
+      ansible.builtin.command: >
+        ansible-playbook -c local -v -b {{ remote_plugin.arguments }} --extra-vars='{{ remote_plugin.parameters }}' /rsc/plugins/{{ item.name}}/{{ item.path }}
       register: ansible_on_workspace
       changed_when: "'changed=0' not in ansible_on_workspace.stdout_lines[-1]"
       vars:
         remote_plugin:
-          script_type: 'Ansible PlayBook'
-          arguments: "-i 127.0.0.1, --skip-tags {{ ansible_skip_tags | join(',') }}"
+          script_type: Ansible PlayBook
+          arguments: -i 127.0.0.1, --skip-tags {{ ansible_skip_tags | join(',') }}
           parameters: "{{ item.parameters | default('{}') }}"
       with_items: "{{ lookup('env', 'components') }}"

--- a/molecule/ext/molecule-src/default.env.yml
+++ b/molecule/ext/molecule-src/default.env.yml
@@ -2,6 +2,6 @@
 # Default Molecule .env.yml file
 # NOTE: to make molecule use this file, place it in the root of your project (or from whichever directory you are calling 'molecule'), and rename it to .env.yml
 PLAYBOOK_DIR: ../../../ # Relative to the default molecule.yml (molecule/ext/molecule-src/molecule.yml)
-ANSIBLE_VERBOSITY: '2'
-ANSIBLE_ROLES_PATH: ../../roles # Relative to your scenario (e.g. molecule/role-foo/..) 
+ANSIBLE_VERBOSITY: "2"
+ANSIBLE_ROLES_PATH: ../../roles # Relative to your scenario (e.g. molecule/role-foo/..)
 REQUIREMENTS_FILE: requirements.txt

--- a/molecule/ext/molecule-src/prepare.yml
+++ b/molecule/ext/molecule-src/prepare.yml
@@ -3,24 +3,24 @@
   hosts: all
   gather_facts: true
   tasks:
-
     - name: Clone git component
       when: item.git is defined
       ansible.builtin.git:
-          repo: "{{ item.git }}"
-          dest: "/rsc/plugins/{{ item.name }}/"
-          refspec: "{{ item.refspec | default(omit) }}"
+        repo: "{{ item.git }}"
+        dest: /rsc/plugins/{{ item.name }}/
+        refspec: "{{ item.refspec | default(omit) }}"
       with_items: "{{ lookup('env', 'components') }}"
+      tags: skip_ansible_lint # linter complains about idempotence of git module
 
     - name: Copy local component
       when: item.git is not defined
       ansible.posix.synchronize:
         src: "{{ item.dir | default(lookup('env', 'PLAYBOOK_DIR')) }}/"
-        dest: "/rsc/plugins/{{ item.name }}/"
+        dest: /rsc/plugins/{{ item.name }}/
         archive: false
         recursive: true
         rsync_opts:
-          - '--exclude=".*"'
+          - --exclude=".*"
         ssh_connection_multiplexing: true
       with_items: "{{ lookup('env', 'components') }}"
 

--- a/molecule/ext/molecule-src/requirements.yml
+++ b/molecule/ext/molecule-src/requirements.yml
@@ -1,0 +1,5 @@
+---
+# This file is just to specify requirements for running the liter on the SRC-Molecule repository.
+collections:
+  - name: ansible.posix
+  - name: community.general


### PR DESCRIPTION
Normally this can be done with:

 `git subtree pull --prefix molecule/ext/molecule-src molecule-src main`

However, I needed to do this manually, as I had squashed the last subtree commit together with some other commits. This meant that `git subtree pull` didn't work, because it couldn't find the last time the subtree was added in the git log. So I did it 'manually', for once -- here's the command for posterity:

`git merge -s subtree -Xsubtree="molecule/ext/molecule-src" -Xtheirs molecule-src/main  --allow-unrelated-histories --squash`