### PR TITLE
Fix pyenv role on Ubuntu 22. Resolves #51

### DIFF
--- a/.env.yml
+++ b/.env.yml
@@ -3,5 +3,6 @@
 # NOTE: to make molecule use this file, place it in the root of your project (or from whichever directory you are calling 'molecule'), and rename it to .env.yml
 PLAYBOOK_DIR: ../../../playbooks/ # Relative to the default molecule.yml (molecule/ext/molecule-src/molecule.yml)
 ANSIBLE_VERBOSITY: '2'
-ANSIBLE_ROLES_PATH: ../../playbooks/roles # Relative to your scenario (e.g. molecule/role-foo/..) 
+ANSIBLE_ROLES_PATH: ../../playbooks/roles # Relative to your scenario (e.g. molecule/role-foo/..)
+ANSIBLE_STDOUT_CALLBACK: yaml
 REQUIREMENTS_FILE: requirements.txt

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -80,6 +80,7 @@ jobs:
       DOCKER_PW: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_REGISTRY: ghcr.io
       ANSIBLE_FORCE_COLOR: '1'
+      ANSIBLE_STDOUT_CALLBACK: yaml
       MOLECULE_CONFIG: molecule/ext/molecule-src/molecule.yml
       REQUIREMENTS_FILE: molecule/ext/molecule-src/requirements.txt
     strategy:

--- a/molecule/playbook-python-workbench/molecule.yml
+++ b/molecule/playbook-python-workbench/molecule.yml
@@ -1,13 +1,4 @@
 ---
-platforms: # Test only on ubuntu focal due to pyenv role bug on jammy: https://github.com/UtrechtUniversity/researchcloud-items/issues/51
-  - name: workspace-src-ubuntu_focal
-    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_focal
-    pre_build_image: true
-    registry:
-      url: $DOCKER_REGISTRY
-      credentials:
-        username: $DOCKER_USER
-        password: $DOCKER_PW
 provisioner:
   name: ansible
   env:

--- a/molecule/playbook-python-workbench/verify.yml
+++ b/molecule/playbook-python-workbench/verify.yml
@@ -3,13 +3,18 @@
   hosts: all
   gather_facts: false
   tasks:
-    # Just check whether the userspace definitions have been installed, as there are no separate tests for the userspace role yet.
+    # Just check whether the userspace definitions have been installed, and trust the userspace role to do its job
     - name: Check whether poetry runonce defintion is installed
       ansible.builtin.stat:
-        path: /home/testuser/runonce.d/10-python-poetry
-      register: poetry_stat
+        path: "/home/testuser/runonce.d/{{ item }}"
+      register: expected_files
+      with_items:
+        - 05-python-3.9.9
+        - 10-python-poetry
+        - 999ready
 
-    - name: Assert poetry definition exists
+    - name: Assert expected files exist
       ansible.builtin.assert:
         that:
-          - poetry_stat.stat.exists
+          - "{{ item }}.stat.exists"
+      with_items: "{{ expected_files.results }}"

--- a/playbooks/python-workbench.yml
+++ b/playbooks/python-workbench.yml
@@ -10,6 +10,6 @@
     - role: userspace_applications
       vars:
         list_userspace_applications:
-          - "05-python-3.9.9"
+          - 05-python-3.9.9
           - 10-python-poetry
           - 999ready

--- a/playbooks/roles/pyenv/tasks/main.yml
+++ b/playbooks/roles/pyenv/tasks/main.yml
@@ -27,16 +27,14 @@
     - libbz2-dev
     - libreadline-dev
     - libsqlite3-dev
-    - wget
     - curl
-    - llvm
     - libncurses5-dev
     - libncursesw5-dev
     - xz-utils
     - tk-dev
     - libffi-dev
     - liblzma-dev
-    - python-openssl
+    - python3-openssl
   when: ansible_pkg_mgr == 'apt'
 
 - name: Add pyenv install to runonce config


### PR DESCRIPTION
Use `python3-openssl` instead of `python-openssl`. Also adds a `verify.yml` for the python-workbench component, and applies `ansible-lint`.