### PR TITLE
Update miniconda.md

### DIFF
--- a/docs/playbooks/miniconda.md
+++ b/docs/playbooks/miniconda.md
@@ -10,9 +10,9 @@ Unix-environment.
 ## Description
 Miniconda can be installed either for each user individually, or once and be shared amongst all users. 
 Both options cannot be selected simultaneously.
-By default it is installed multiple times, for each user individually.
+By default it is installed systemwide. If the option to install for all users is selected, it will be installed at the first login of each user.
 It follows the official documentation's recommended way of installation.
-When it is installed, alles users share both a list of environments and their packages.
+When it is installed, allows users to share both a list of environments and their packages.
 Possible to-do would be to toggle whether user share packages amongst each other.
 
 ## Variables


### PR DESCRIPTION
@jelletreep I noticed there was a difference between the docs for miniconda and the actual default behaviour: we have set systemwide as default, but the docs say the default is to install for each user. I've corrected the docs here *but* we could also correct the setting. Which default do you think is better?

Two additional questions about the miniconda component:

* the docs mention as a possible todo that we could let users share packages etc. Is that still something we should work on? Isn't a systemwide installation a better option in that case?
* I see the miniconda component is currently only visible for certain COs. Perhaps we could make it publicly available?