### PR TITLE
Fix miniconda booleans

### DIFF
--- a/molecule/playbook-miniconda/molecule.yml
+++ b/molecule/playbook-miniconda/molecule.yml
@@ -10,3 +10,4 @@ provisioner:
         path: miniconda.yml
         parameters:
           miniconda_userspace: 'true'
+          miniconda_autoinit: 'true'

--- a/molecule/role-miniconda/converge.yml
+++ b/molecule/role-miniconda/converge.yml
@@ -5,10 +5,12 @@
   tasks:
     # This scenario tests the role with the 'miniconda_systemwide' parameter set to true.
     # The scenario 'playbook-miniconda' utilizes the role with the parameter set to false, so no separate role test for that use case is needed.
+    # Similarly, test with the auto_init
     - name: Testing systemwide miniconda installation
       include_role:
         name: miniconda
       vars:
-        miniconda_systemwide: true
-        miniconda_userspace: false
+        miniconda_systemwide: 'true'
+        miniconda_userspace: 'false'
         miniconda_install_dir: /data/ext/miniconda
+        miniconda_auto_init: 'false'

--- a/molecule/role-miniconda/verify.yml
+++ b/molecule/role-miniconda/verify.yml
@@ -11,6 +11,7 @@
 
     - name: Look for proof that conda init was run
       ansible.builtin.command: grep conda /home/testuser2/.bashrc
+      failed_when: false
       register: conda_init
 
     - name: Stat miniconda global
@@ -29,10 +30,10 @@
           - miniconda_systemwide.stat.exists is true
           - miniconda_userspace.stat.exists is false
 
-    - name: Assert conda initialized
+    - name: Assert conda not initialized
       ansible.builtin.assert:
         that:
-          - '"conda initialize >>>" in conda_init.stdout'
+          - '"conda initialize >>>" not in conda_init.stdout'
 
     - name: Test conda list
       ansible.builtin.command: su - -l -c "/data/ext/miniconda/bin/conda list" testuser2

--- a/playbooks/roles/miniconda/tasks/main.yml
+++ b/playbooks/roles/miniconda/tasks/main.yml
@@ -1,10 +1,17 @@
 ---
+
+- name: Convert parameters to booleans
+  set_fact:
+    install_systemwide: "{{ miniconda_systemwide | bool }}"
+    install_userspace: "{{ miniconda_userspace | bool }}"
+    auto_init: "{{ miniconda_auto_init | bool }}"
+
 - name: Check if not both systemwide and userspace are true or false
-  when: miniconda_userspace == miniconda_systemwide
+  when: install_systemwide == install_userspace
   meta: end_play
 
 - name: Create miniconda multi-user group and add new users to it automatically
-  when: miniconda_systemwide
+  when: install_systemwide
   include_role:
     name: default_group
   vars:
@@ -26,18 +33,18 @@
 
 # Done in seperate task file to allow proper looping with fact_regular_users.
 - name: Install per user
-  when: miniconda_userspace
+  when: install_userspace
   include_tasks: install_user.yml
   with_items:
     - "{{ fact_regular_users }}"
 
 # Done in seperate task to be consistent, since per-user installation is also done that way.
 - name: Install system-wide
-  when: miniconda_systemwide
+  when: install_systemwide
   include_tasks: install_system.yml
 
 - name: Set `conda init` command
-  when: miniconda_systemwide
+  when: install_systemwide
   set_fact:
     miniconda_conda_init: "{{ miniconda_install_dir }}/bin/conda init"
 

--- a/playbooks/roles/miniconda/templates/runonce_conda.sh.j2
+++ b/playbooks/roles/miniconda/templates/runonce_conda.sh.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-{% if miniconda_userspace -%}
+{% if install_userspace -%}
 MINICONDA_DEST=~/miniconda
 if [[ ! -d "$MINICONDA_DEST" ]]; then
     echo "Installing miniconda"
@@ -9,7 +9,7 @@ if [[ ! -d "$MINICONDA_DEST" ]]; then
 fi
 {% endif -%}
 
-{% if miniconda_auto_init -%}
+{% if auto_init -%}
 echo "Running miniconda init"
 #
 {{ miniconda_conda_init }}


### PR DESCRIPTION
Because of #56 boolean parameters in the portal weren't being processed as booleans.