### PR TITLE
Add markdown link checker for docs

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -1,0 +1,14 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        config-file: .markdown_link_check.json
+        folder-path: docs
+        file-path: './README.md, ./TESTING.md, CONTRIBUTING.md'

--- a/.markdown_link_check.json
+++ b/.markdown_link_check.json
@@ -1,0 +1,16 @@
+{
+  "httpHeaders": [
+    {
+      "urls": ["https://github.com/", "https://guides.github.com/", "https://help.github.com/", "https://docs.github.com/"],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ],
+  "aliveStatusCodes": [200, 401, 403],
+  "ignorePatterns": [
+    {
+      "pattern": "^https:\/\/.*\.src\.surf-hosted\.nl"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Some of the code maintained in this repo is derived from other sources. As a con
 2) In all other cases the license specified in the top-level directory of this repository applies. 
 
 ## Contributing
-We are very happy with any contributions in terms of new Ansible scripts for Research Plug-ins and/or documentation. Read the contributing [guidelines](/CONTRIBUTING.md).
+We are very happy with any contributions in terms of new Ansible scripts for Research Plug-ins and/or documentation. Read the contributing [guidelines](./CONTRIBUTING.md).
 
 ## CI
 

--- a/docs/primer/introduction.md
+++ b/docs/primer/introduction.md
@@ -1,71 +1,7 @@
-# What is SURF ResearchCloud
+# Introduction
 [back to index](../primer-for-users.md)
 
-## Introduction
-Surf ResearchCloud (SRC) is a service that allows you to use the vast computational power offered 
-by datacenters with almost the same ease-of-use as using your own laptop. 
-The complex infrastructure behind the scenes is presented to you as a *workspace*. Think
-of a workspace as a laptop-in-the-cloud that you access using your web browser or another
-application (for instance "Remote Desktop" or "ssh").
-Your web browser displays the screen content of this workspace and allows you to interact with
-it using your keyboard and mouse. 
-
-Workspaces are preconfigured with one or more applications, ranging from RStudio, Jupyter Notebooks, Matlab, to plain Windows or Linux virtual machines where the user installs their own software. Workspaces are also scalable:
-computational power, GPU drivers and extra storage can be ordered with a single mouse click.
-You can select a workspace type that suites your needs from a catalog in 
-the [SRC web portal](https://portal.live.surfresearchcloud.nl). 
-Workspaces are preconfigured for the user by support staff and can be extended on request to suit a variety of research domains and analysis methods. 
-Should analysis applications for your domain not yet be covered, the support staff is happy to assist 
-and to make additions to the catalog.
-
-Ordering a workspace is easy. In the SRC portal, just click on a workspace type to order it. The 
-datacenter service will set aside some compute power for you. 
-The datacenter subsequently creates a workspace and prepares it for you with applications preinstalled. 
-This whole process takes approximately 10 to 30 minutes, depending on the type of workspace.
-
-A workspace is offered on-demand and on a pay-as-you-go basis. 
-It saves you much hassle: no need to buy and maintain computer hardware and
-your favorite applications come conveniently preinstalled for you.
-This resource leasing concept is a cost effective solution if you plan to use it part-time, 
-or if you seek to avoid to invest in expensive computer hardware, software or related IT-skills.
-Once you are done with using your workspace, just dispose of it in the SRC web portal.
-
-**Example workspaces**
-- Rstudio
-- Jupyter
-- Matlab
-- Python with Machine learning libraries   
-- Customized workspaces e.g. ASReview   
-- Windows Server (install your own software)
-- Ubuntu (install your own software)
-
-**Resources available for a single workspace**
-- up to 80 CPU cores
-- up to 480 GB RAM
-- up to 4 GPU drives
-- up to 2 TB storage
-
-## Designed with consortia and other Collaborative use in mind
-Often, workspaces will need to be used by research staff from different institutes. 
-The organizational structure may vary from an ad-hoc project team to a legal entity representing a
-consortium. 
-Solutions such as guest accounts for staff from other institutes could lead to scenarios where
-the guests are deprived from important features.
-
-To overcome such limitations, SRC instead uses the concept of a collaboration.
-A collaboration may be viewed as a *virtual* organization, with members that can originate
-from different research institutes, or from the private sector. Members may also have joined 
-on a personal title. 
-It is important to understand that SRC assumes all members of the collaboration to be 
-contractually or otherwise bound to work together.  
-Hence the costs related to a workspace ordered by a single member of the collaboration are 
-effectively charged to the collaboration. In addition, the workspace is automatically accessible
-to  all members of the collaboration.
-
-A collaboration can accommodate a virtual organization the size of a European research project consortium.
-In contrast, it might also consist of just a single member, a researcher in need of a private workspace.
-Managing membership is done via a self-service portal (called [SRAM](https://sram.surf.nl), 
-short for SURF Research Access Management. 
+See [here](https://utrechtuniversity.github.io/vre-docs/docs/research-cloud-intro.html) for a general explanation of what ResearchCloud is.
 
 ## Membership and Wallets
 As an Utrecht University employee or student, you can be invited by a colleague to an existing SRC collaboration.
@@ -87,7 +23,7 @@ wallet request.
 
 
 ## GETTING STARTED
-The [SURF ResearchCloud Wiki](https://servicedesk.surfsara.nl/wiki/display/WIKI/Research+Cloud+Documentation)
+The [SURF ResearchCloud Wiki](https://servicedesk.surf.nl/wiki/display/WIKI/SURF+Research+Cloud)
 pages provide an elaborate introduction on concepts related to this cloud service. 
 
 Practical instructions to get started on SRC can be found [here](first-time-use.md).

--- a/docs/roles/poetry.md
+++ b/docs/roles/poetry.md
@@ -9,7 +9,7 @@ Poetry is a Python package version management tool for easy packageing and depen
 * Python 3.7+
 
 ## Description
-This role will install poetry through the official documentation's [recommended installed](https://python-poetry.org/docs/master/#installing-with-the-official-installer).
+This role will install poetry through the official documentation's [recommended installed](https://python-poetry.org/docs/#installing-with-the-official-installer).
 The installation is done on a per-user basis, as per the application's designed usage.
 The actual installation is run at user login time through the runonce role.
 

--- a/docs/roles/robotuser.md
+++ b/docs/roles/robotuser.md
@@ -71,7 +71,7 @@ instead of a client.
 ## See also
 - [sshfs-mount](sshfs-mount.md)
 - [sshfs-umount](sshfs-umount.md)
-- [sshfs-configrobot](sshfs-configrobot)
+- [sshfs-configrobot](sshfs-configrobot.md)
 
 ## History
 2021 Written by Ton Smeele (Utrecht University)

--- a/docs/roles/sshfs-configrobot.md
+++ b/docs/roles/sshfs-configrobot.md
@@ -9,7 +9,7 @@ over ssh protocol where the client authenticates as robotuser.
 Role [robotuser](robotuser.md) has been executed prior to invocation of this role.
 
 ## Description
-An [sshfs-mount](sshfs-mount) requires scripts to specify parameters for connecting the client to a server, 
+An [sshfs-mount](sshfs-mount.md) requires scripts to specify parameters for connecting the client to a server, 
 such as username, server address, and directory used as data source.
  
 When a robotuser account is used for authentication with the server, we may opt to use default connection

--- a/docs/roles/tweet_collector.md
+++ b/docs/roles/tweet_collector.md
@@ -16,7 +16,7 @@ A function is added to catch the launch commands, and first activates the virtua
 Mention any variables that can be preset by the user, and their defaults
 
 ## See also
-Role [poetry](../roles/poetry) Dependency for installing the tweet-collector
+Role [poetry](./poetry.md) Dependency for installing the tweet-collector
 
 ## History
 2022 Written by Sytse Groenwold (Utrecht University)


### PR DESCRIPTION
Resolves #59

This PR adds automatic link checking for links in the markdown files in this repo, which is especially relevant for the docs.