### PR TITLE
Patch shebang in xrdp shell script

### DIFF
--- a/playbooks/roles/runonce/tasks/main.yml
+++ b/playbooks/roles/runonce/tasks/main.yml
@@ -3,6 +3,23 @@
 #  the scripts should be placed in /etc/runonce.d with read-access for all users
 # 
 
+# See https://github.com/neutrinolabs/xrdp/issues/1009
+# This is fixed in xrdp v0.10, but Ubuntu 20 still has 0.9
+- name: Patch /etc/xrdp/startwm.sh
+  block:
+    - name: Check if shebang is wrong
+      command: grep "#\!/bin/sh" /etc/xrdp/startwm.sh
+      changed_when: false
+      failed_when: false
+      register: _runonce_check_startwm
+
+    - name: Replace shebang
+      lineinfile:
+        path: /etc/xrdp/startwm.sh
+        regexp: '#!/bin/sh'
+        line: '#!/usr/bin/env bash'
+      when: _runonce_check_startwm.rc == 0
+
 - name: install runonce.sh in /etc/profile.d
   copy:
     src: "runonce.sh"


### PR DESCRIPTION
I noticed we were unable to login to Desktop variants of the Python Workbench components. This turns out to be because `xrdp` starts the scripts in `/etc/profile` using `/bin/sh` instead of `bash`, and our `runonce` scripts use bash-specific syntax.

The underlying issue has been fixed in newer versions of xrdp, but Ubuntu 20.04 still has an older version. Therefore this PR patches the script used by `xrdp` to use `bash` instead of `sh`.

See https://github.com/neutrinolabs/xrdp/issues/1009 