### PR TITLE
role uu_generic: install IDEs for desktop envs

### DIFF
--- a/playbooks/roles/uu_generic/meta/main.yml
+++ b/playbooks/roles/uu_generic/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Dawa Ometto
-  description: Provision the workspace with standard UU info, such as documentation links in motd.
+  description: Provision the workspace with standard UU features, such as documentation links in motd.
   license: GPLv3
   min_ansible_version: '2.9'
   platforms:

--- a/playbooks/roles/uu_generic/tasks/desktop.yml
+++ b/playbooks/roles/uu_generic/tasks/desktop.yml
@@ -1,0 +1,10 @@
+---
+# Tasks that should be executed on all desktop workspaces
+
+- name: Install IDEs from snap
+  community.general.snap:
+    name:
+      - codium
+      - pycharm-community
+    classic: true
+    state: present

--- a/playbooks/roles/uu_generic/tasks/docs.yml
+++ b/playbooks/roles/uu_generic/tasks/docs.yml
@@ -1,0 +1,53 @@
+---
+# Place references to documentation on the workspace
+
+- name: Set motd (Ubuntu/Debian)
+  when: ansible_os_family == "Debian"
+  block:
+    - name: Add UU motd message
+      ansible.builtin.template:
+        src: 99-uu
+        dest: /etc/update-motd.d/99-uu
+        owner: root
+        mode: "755"
+
+    - name: Remove superfluous motd parts
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      failed_when: false
+      with_items:
+        - /etc/update-motd.d/91-contract-ua-esm-statu
+        - /etc/update-motd.d/50-motd-news
+
+- name: Add documentation link (Ubuntu/Debian)
+  when: fact_desktop_workspace and ansible_os_family == "Debian"
+  block:
+    - name: Combine /etc/skel with fact_regular_users
+      ansible.builtin.set_fact:
+        uu_generic_desktop_dirs: >
+          {{
+            fact_regular_users + [{
+              'home': '/etc/skel',
+              'user': 'root',
+              'groupid': 'root'
+              }]
+          }}
+
+    - name: Create Desktop folders
+      ansible.builtin.file:
+        path: "{{ item.home }}/Desktop"
+        state: directory
+        owner: "{{ item.user }}"
+        group: "{{ item.groupid }}"
+        mode: "0775"
+      with_items: "{{ uu_generic_desktop_dirs }}"
+
+    - name: Create desktop items
+      ansible.builtin.template:
+        src: shortcut.desktop
+        dest: "{{ item.home }}/Desktop/ResearchCloud Help.desktop"
+        owner: "{{ item.user }}"
+        group: "{{ item.groupid }}"
+        mode: "0775"
+      with_items: "{{ uu_generic_desktop_dirs }}"

--- a/playbooks/roles/uu_generic/tasks/main.yml
+++ b/playbooks/roles/uu_generic/tasks/main.yml
@@ -1,51 +1,7 @@
 ---
-- name: Set motd (Ubuntu/Debian)
-  when: ansible_os_family == "Debian"
-  block:
-    - name: Add UU motd message
-      ansible.builtin.template:
-        src: 99-uu
-        dest: /etc/update-motd.d/99-uu
-        owner: root
-        mode: "755"
+- name: Include documentation tasks
+  include_tasks: docs.yml
 
-    - name: Remove superfluous motd parts
-      ansible.builtin.file:
-        path: "{{ item }}"
-        state: absent
-      failed_when: false
-      with_items:
-        - /etc/update-motd.d/91-contract-ua-esm-statu
-        - /etc/update-motd.d/50-motd-news
-
-- name: Add documentation link (Ubuntu/Debian)
-  when: fact_desktop_workspace and ansible_os_family == "Debian"
-  block:
-    - name: Combine /etc/skel with fact_regular_users
-      ansible.builtin.set_fact:
-        uu_generic_desktop_dirs: >
-          {{
-            fact_regular_users + [{
-              'home': '/etc/skel',
-              'user': 'root',
-              'groupid': 'root'
-              }]
-          }}
-
-    - name: Create Desktop folders
-      ansible.builtin.file:
-        path: "{{ item.home }}/Desktop"
-        state: directory
-        owner: "{{ item.user }}"
-        group: "{{ item.groupid }}"
-        mode: "0775"
-      with_items: "{{ uu_generic_desktop_dirs }}"
-
-    - name: Create desktop items
-      ansible.builtin.template:
-        src: shortcut.desktop
-        dest: "{{ item.home }}/Desktop/ResearchCloud Help.desktop"
-        owner: "{{ item.user }}"
-        group: "{{ item.groupid }}"
-        mode: "0775"
-      with_items: "{{ uu_generic_desktop_dirs }}"
+- name: Include generic desktop tasks
+  when: fact_desktop_workspace
+  include_tasks: desktop.yml


### PR DESCRIPTION
Resolves #136

We have to wait with merging this PR until we can install Ansible Galaxy collections on SRC, since this relies on `community.general.snap`.