### PR TITLE
Fix runonce on desktop workspaces

### DIFF
--- a/playbooks/roles/runonce/files/uu-runonce.desktop
+++ b/playbooks/roles/runonce/files/uu-runonce.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=UU Runonce
+Comment=Run configured scripts for ResearchCloud at first login.
+Exec=/bin/bash -l -i /etc/profile.d/runonce.sh
+Type=Application
+NoDisplay=true
+Icon=
+Path=
+Terminal=false
+StartupNotify=false

--- a/playbooks/roles/runonce/meta/main.yml
+++ b/playbooks/roles/runonce/meta/main.yml
@@ -1,4 +1,3 @@
 ---
-
 dependencies:
-- fact_regular_users
+  - fact_regular_users

--- a/playbooks/roles/runonce/meta/main.yml
+++ b/playbooks/roles/runonce/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - fact_regular_users
+  - fact_workspace_info

--- a/playbooks/roles/runonce/tasks/main.yml
+++ b/playbooks/roles/runonce/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 #  ensure that when users login for the first time, a set of scripts are run (once)
 #  the scripts should be placed in /etc/runonce.d with read-access for all users
-# 
+#
 
 # See https://github.com/neutrinolabs/xrdp/issues/1009
 # This is fixed in xrdp v0.10, but Ubuntu 20 still has 0.9
@@ -20,38 +20,36 @@
         line: '#!/usr/bin/env bash'
       when: _runonce_check_startwm.rc == 0
 
-- name: install runonce.sh in /etc/profile.d
+- name: Install runonce.sh in /etc/profile.d
   copy:
     src: "runonce.sh"
     dest: "/etc/profile.d/runonce.sh"
-    mode: 0644
+    mode: "0644"
 
-- name: ensure directory /etc/runonce.d exists
+- name: Ensure directory /etc/runonce.d exists
   file:
     path: "/etc/runonce.d"
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
- 
-# NB: link needs "follow:no" otherwise owner/group would be applied to its src 
-- name: add link to /etc/runonce.d in /etc/skel
+
+# NB: link needs "follow:no" otherwise owner/group would be applied to its src
+- name: Add link to /etc/runonce.d in /etc/skel
   file:
     src: "/etc/runonce.d"
     dest: "/etc/skel/runonce.d"
     owner: root
     group: root
     state: link
-    follow: no
+    follow: false
 
-- name: add link to runonce dir in home of existing users
+- name: Add link to runonce dir in home of existing users
   file:
     src: "/etc/runonce.d"
-    dest: "/{{item.home}}/runonce.d"
-    owner: "{{item.user}}"
-    group: "{{item.user}}"
+    dest: "/{{ item.home }}/runonce.d"
+    owner: "{{ item.user }}"
+    group: "{{ item.user }}"
     state: link
-    follow: no
-  with_items: "{{fact_regular_users}}"
-  
-
+    follow: false
+  with_items: "{{ fact_regular_users }}"

--- a/playbooks/roles/runonce/tasks/main.yml
+++ b/playbooks/roles/runonce/tasks/main.yml
@@ -34,6 +34,13 @@
     owner: root
     group: root
 
+- name: Add runonce to autostart for desktop environment
+  when: fact_desktop_workspace
+  copy:
+    src: uu-runonce.desktop
+    dest: /etc/xdg/autostart/uu-runonce.desktop
+    mode: "0644"
+
 # NB: link needs "follow:no" otherwise owner/group would be applied to its src
 - name: Add link to /etc/runonce.d in /etc/skel
   file:


### PR DESCRIPTION
Resolves #141.

Starts the runonce bootstrap script using a desktop startup item in `/etc/xdg/autostart`.