### PR TITLE
Ensure shared directories are group-writable

### DIFF
--- a/docs/playbooks/shared_directories.md
+++ b/docs/playbooks/shared_directories.md
@@ -17,8 +17,9 @@ Workspaces come with a `/scratch` directory meant for collaboration between user
 
 ## Variables
 
-* `group_name`: name of the group to be created (default: `sharing`).
-* `paths`: comma-separated paths to the directories which should receive `set_gid` (default: `/shared`).
+* `group_name`: String. Name of the group to be created (default: `sharing`).
+* `group_writable`: Boolean. Whether the created shared directories should be writeable by the shared group (`true`) or only readable (`false`) (default: `true`).
+* `paths`: String. Comma-separated paths to the directories which should receive `set_gid` (default: `/shared`).
 
 ## See also
 

--- a/molecule/playbook-shared_directories/molecule.yml
+++ b/molecule/playbook-shared_directories/molecule.yml
@@ -8,3 +8,4 @@ provisioner:
         parameters:
           paths: /shared, /home/testuser/shared,/scratch
           group_name: testgroup
+          group_writable: 'false'

--- a/molecule/playbook-shared_directories/verify.yml
+++ b/molecule/playbook-shared_directories/verify.yml
@@ -30,7 +30,7 @@
     - name: Assert shared folder has correct mode and ownership
       ansible.builtin.assert:
         that:
-          - "'drwxrws' in item.stdout"
+          - "'drwxr-s' in item.stdout"
           - "'root testgroup' in item.stdout"
       with_items:
         - "{{ list_dir1 }}"

--- a/playbooks/shared_directories.yml
+++ b/playbooks/shared_directories.yml
@@ -2,17 +2,19 @@
 - name: Create directories in which all files are automatically writeable by members of the 'shared' group.
   hosts: localhost
   gather_facts: true
+  vars:
+    _group_name: "{{ group_name | default('shared') }}"
   roles:
     - role: default_group
       vars:
         default_group_group:
-          groupname: "{{ group_name }}"
+          groupname: "{{ _group_name }}"
   tasks:
     - name: Create all shared directories with setgid
       ansible.builtin.file:
         path: "{{ item | trim }}"
         owner: "root"
-        group: "{{ group_name }}"
+        group: "{{ _group_name }}"
         mode: "02770"
         state: directory
         recurse: true

--- a/playbooks/shared_directories.yml
+++ b/playbooks/shared_directories.yml
@@ -4,6 +4,7 @@
   gather_facts: true
   vars:
     _group_name: "{{ group_name | default('shared') }}"
+    _group_writable: "{{ group_writable | default('true', true) | bool | ternary('7','5') }}"
   roles:
     - role: default_group
       vars:
@@ -15,7 +16,7 @@
         path: "{{ item | trim }}"
         owner: "root"
         group: "{{ _group_name }}"
-        mode: "02770"
+        mode: "027{{ _group_writable }}0"
         state: directory
         recurse: true
       with_items: "{{ paths.split(',') }}"


### PR DESCRIPTION
Resolves #133.

Looking at the playbook, shared directories *should* be writable already. This branch is to investigate the component.

We could possibly also make the directories optionally read-only for the group.