### PR TITLE
update Ephor playbook and Rstudio roles 

### DIFF
--- a/playbooks/ephor.yml
+++ b/playbooks/ephor.yml
@@ -7,6 +7,5 @@
     - irods_iselect
     - irods_skel
     - myrods-sync
-    - tidyverse-dependencies
     - rstudio
 ...

--- a/playbooks/ephor.yml
+++ b/playbooks/ephor.yml
@@ -2,10 +2,7 @@
 - name: Workspace playbook for Ephor use-case
   hosts: localhost
   roles:
-    - irods_repo
-    - irods_icommands
     - irods_iselect
-    - irods_skel
     - myrods-sync
     - rstudio
 ...

--- a/playbooks/roles/rstudio/tasks/main.yml
+++ b/playbooks/roles/rstudio/tasks/main.yml
@@ -1,7 +1,13 @@
 ---
-- name: Install RStudio for Debian
-  when: ansible_os_family == 'Debian'
+- name: Install RStudio for Ubuntu 20
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version == "20.04"
   apt:
     deb: https://download1.rstudio.org/electron/focal/amd64/rstudio-2024.04.2-764-amd64.deb
+    state: present
+    
+- name: Install RStudio for Ubuntu 22
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version == "22.04"
+  apt:
+    deb: https://download1.rstudio.org/electron/jammy/amd64/rstudio-2024.04.2-764-amd64.deb
     state: present
 ...

--- a/playbooks/roles/rstudio/tasks/main.yml
+++ b/playbooks/roles/rstudio/tasks/main.yml
@@ -1,38 +1,7 @@
 ---
-- name: Install R for Debian
-  when: ansible_os_family == 'Debian'
-  apt:
-    name: r-base
-    update_cache: yes
-    state: present
-
-- name: Install R dev
-  when: ansible_os_family == 'Debian'
-  apt:
-    name: r-base-dev
-    state: present
-
 - name: Install RStudio for Debian
   when: ansible_os_family == 'Debian'
   apt:
-    deb: https://download1.rstudio.org/electron/focal/amd64/rstudio-2023.06.1-524-amd64.deb
-    state: present
-
-# - name: Update extra packages for CentOS
-#   when: ansible_os_family == 'CentOS'
-#   yum:
-#     name: epel-release
-#     state: latest
-
-- name: Install R on CentOS
-  when: ansible_os_family == 'CentOS'
-  yum:
-    name: R
-    state: present
-
-- name: Install RStudio for CentOS
-  when: ansible_os_family == 'CentOS'
-  yum:
-    name: https://s3.amazonaws.com/rstudio-ide-build/desktop/rhel8/x86_64/rstudio-2022.02.0-443-x86_64.rpm
+    deb: https://download1.rstudio.org/electron/focal/amd64/rstudio-2024.04.2-764-amd64.deb
     state: present
 ...


### PR DESCRIPTION
@dometto, i made some updates for the Ephor project. Because I added the "iRods tools " and "r workbench" components, I could remove some redundant roles from this playbook. Note that the Rstudio role is also updated. I removed the installation of R because it is done in r workbench, and centOS installation because centOS is not supported anymore if I am correct. 
Any idea if the R studio role is used elsewhere? Is it an idea to add Rstudio to r workbench by default (for desktop workspaces)? @chStaiger do you think it is useful for Emilia's project as well?

I created a workspace and everything seems to work as expected!
