### PR TITLE
r-workbench: add rstudio on desktop workspaces.

### DIFF
--- a/playbooks/ephor.yml
+++ b/playbooks/ephor.yml
@@ -5,5 +5,4 @@
     - irods_iselect
     - myrods_sync
     - tidyverse_dependencies
-    - rstudio
 ...

--- a/playbooks/r-workbench.yml
+++ b/playbooks/r-workbench.yml
@@ -4,11 +4,14 @@
   gather_facts: true
 
   roles:
+    - role: fact_workspace_info
     - role: tidyverse_dependencies  # install tidyverse dependencies
     - role: install_role
       vars:
         install_role_roles:
           - git+https://github.com/UtrechtUniversity/ansible-r.git,f9694f503a96cda62898b1ad893c4d0d94798ea1
+    - role: rstudio
+      when: fact_desktop_workspace
 
   tasks:
 


### PR DESCRIPTION
Resolves #182

- [x] Make sure this does not lead to duplication of RStudio in certain playbooks (ephor).