### PR TITLE
chore: only run tests for non-draft PRs

### DIFF
--- a/.github/workflows/molecule_playbooks.yml
+++ b/.github/workflows/molecule_playbooks.yml
@@ -7,10 +7,16 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
 
   define_scenarios:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/molecule_roles.yml
+++ b/.github/workflows/molecule_roles.yml
@@ -7,10 +7,16 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
 
   get_changed_roles:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.changed-roles.outputs.all_changed_files }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ In short:
 5. Submit a pull request from that branch to the main branch of the master repository. 
 6. If you receive feedback, make changes on your desktop and push to your branch on GitHub: the pull request will update automatically.
 
+**Note**: in order not to needlessly trigger test workflows, please convert your PR to a draft while you are still working on it. When ready, mark your PR as "ready for review". This will ensure tests are run.
+
 ## Style guides
 
 ### Branch naming conventions


### PR DESCRIPTION
Implements the recommendations [here](https://blog.esciencecenter.nl/reduce-reuse-recycle-save-the-planet-one-github-action-at-a-time-4ab602255c3f) to run tests only on PRs marked 'ready for review'. Saves a lot of energy. :)