### PR TITLE
update agisoft version

### DIFF
--- a/playbooks/agisoft.yml
+++ b/playbooks/agisoft.yml
@@ -3,5 +3,7 @@
   hosts: localhost
   gather_facts: true
   roles:
-    - agisoft
+    - role: agisoft
+      vars:  
+        lic_file_lines: "{{ content | split('\n') }}"
 ...

--- a/playbooks/agisoft.yml
+++ b/playbooks/agisoft.yml
@@ -5,5 +5,5 @@
   roles:
     - role: agisoft
       vars:  
-        lic_file_lines: "{{ content | split('\n') }}"
+        license: "{{ content | replace('\\n', '\n') }}"
 ...

--- a/playbooks/roles/agisoft/tasks/main.yml
+++ b/playbooks/roles/agisoft/tasks/main.yml
@@ -26,10 +26,7 @@
 - name: Create license file
   copy:
     dest:  "{{ agisoft_install_dir }}/license.lic"
-    content: |
-      "{{ lic_file_lines[0] }}"
-      "{{ lic_file_lines[1] }}"
-      "{{ lic_file_lines[2] }}"      
+    content: "{{ license }}"
 
 - name: Install desktop file menu item through role
   include_role:

--- a/playbooks/roles/agisoft/tasks/main.yml
+++ b/playbooks/roles/agisoft/tasks/main.yml
@@ -5,6 +5,7 @@
 #  include: "dependencies_{{ ansible_pkg_mgr }}.yml"
 #
 # The get_url ansible module in the task below does not create a directory
+
 - name: Ensure download dir exists
   file:
     path: "{{ agisoft_download_dest }}"
@@ -25,7 +26,10 @@
 - name: Create license file
   copy:
     dest:  "{{ agisoft_install_dir }}/license.lic"
-    content: "{{ content }}"
+    content: |
+      "{{ lic_file_lines[0] }}"
+      "{{ lic_file_lines[1] }}"
+      "{{ lic_file_lines[2] }}"      
 
 - name: Install desktop file menu item through role
   include_role:


### PR DESCRIPTION
@dometto, the new license file of this software consists of multiple lines of text (rather than one), would this be a good way (following best practices) to get them properly from one multi-line research cloud parameter (content) to multiple lines in the text file? In the current version they are printed on one line with `\n`

I didn't test it yet, but am first interested whether there might be preferred ways to achieve this