### PR TITLE
fix: use package manager instead of pip to install module dependency …

### DIFF
--- a/playbooks/reverse_proxy.yml
+++ b/playbooks/reverse_proxy.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install nginx reverse proxies
+- name: Setup nginx reverse proxies
   hosts: localhost
   gather_facts: true
 

--- a/playbooks/roles/nginx_reverse_proxy/tasks/main.yml
+++ b/playbooks/roles/nginx_reverse_proxy/tasks/main.yml
@@ -14,8 +14,8 @@
   when: _htpasswd_files | length > 0
   block:
     - name: Install dependencies for htpasswd module
-      pip:
-        name: passlib
+      package:
+        name: python3-passlib
 
     - name: Create htpasswd location
       file:


### PR DESCRIPTION
It is better to use the dedicated `python3-foo` packages to install python module dependency, as using `pip` may accidentally break system packages.