### PR TITLE
chore: update ibridges variable name

### DIFF
--- a/playbooks/roles/ibridges/defaults/main.yml
+++ b/playbooks/roles/ibridges/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 ibridges_systemwide_location: /usr/local/uu-pip
-ibridges_template_plugin_url: ibridges-servers-uu
+ibridges_template_plugin: ibridges-servers-uu

--- a/playbooks/roles/ibridges/tasks/templates.yml
+++ b/playbooks/roles/ibridges/tasks/templates.yml
@@ -10,7 +10,7 @@
 
 - name: Install iBridges template plugin
   pip:
-    name: "{{ ibridges_template_plugin_url }}"
+    name: "{{ ibridges_template_plugin }}"
     extra_args: "--target {{ _ibridges_find_venv.files[0].path }}/site-packages"
     state: present
   register: ibridges_install_template_plugin


### PR DESCRIPTION
The ibridges template plugin is now a pip package and no longer needs to be installed via a git URL. This PR updates a variable name to reflect this.