### PR TITLE
playbook whisper: add basic tests

### DIFF
--- a/molecule/playbook-whisper/molecule.yml
+++ b/molecule/playbook-whisper/molecule.yml
@@ -1,0 +1,10 @@
+---
+# This playbook test only tests the basic functionality of the component: copying the Notebook file to the user homedir.
+# It does not actually test the functionality of the Notebook. At the time of writing, the Notebook seems not to work on Ubuntu 22...
+# ...due to issues with pip dependencies.
+provisioner:
+  name: ansible
+  env:
+    components:
+      - name: whisper
+        path: whisper.yml

--- a/molecule/playbook-whisper/verify.yml
+++ b/molecule/playbook-whisper/verify.yml
@@ -10,4 +10,4 @@
 
     - name: Assert files exist
       ansible.builtin.assert:
-        that: 'required_files.exists'
+        that: 'required_files.stat.exists'

--- a/molecule/playbook-whisper/verify.yml
+++ b/molecule/playbook-whisper/verify.yml
@@ -1,0 +1,13 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check for required files
+      ansible.builtin.stat:
+        path: /home/testuser/whisper_template.ipynb
+      register: required_files
+
+    - name: Assert files exist
+      ansible.builtin.assert:
+        that: 'required_files.exists'


### PR DESCRIPTION
@jelletreep these are very basic tests that just test whether the notebook ends up in users' homedir. I think we can't and shouldn't really test the notebook's functionality as it requires GPU's anyway?

I noticed Whisper isn't currently listed under https://utrechtuniversity.github.io/researchcloud-items/ -- could you write a quick, basic documentation about what the playbook does (e.g. that it's intended to be run in combination with the Jupyter Notebooks component)?