### PR TITLE
role uv: fix detection of changed installation

### DIFF
--- a/playbooks/roles/uv/tasks/main.yml
+++ b/playbooks/roles/uv/tasks/main.yml
@@ -32,9 +32,9 @@
     uv_python_versions_install: "{{ (uv_python_versions + (uv_venvs | map(attribute='python') | list)) | unique }}"
 
 - name: Install desired python version
-  command: "uv python install {{ item }}"
+  command: "uv python install -v {{ item }}"
   register: _install_desired_python
-  changed_when: '"Found existing installation" not in _install_desired_python.stderr'
+  changed_when: '"Skipping" not in _install_desired_python.stderr'
   with_items: "{{ uv_python_versions_install }}"
 
 - name: Set uv python install path facts step 1


### PR DESCRIPTION
Idempotence tests fail for the `uv` role, it looks like the previously expected warning printed to stderr when a specific python version already exists has disappeared from the latest version. This PR fixes the issue by making the install command verbose and checking for new output.