### PR TITLE
playbook aptly: fix user variable

### DIFF
--- a/playbooks/aptly.yml
+++ b/playbooks/aptly.yml
@@ -55,6 +55,8 @@
             gpg_pubkeyfileexport: aptly.asc
             gpg_privkeyfile: aptly.priv
             gpg_home: /root
+            gpg_user: "{{ aptly_user }}"
+
         - name: Cat GPG private key
           command: cat /root/aptly.priv
           changed_when: false


### PR DESCRIPTION
Resolves #225

The external aptly role uses `ansible_user` as a default GPG user, but that variable does not exist in newer versions of Ansible. Fix by setting the user explicitly.