### PR TITLE
feature: provision workspaces with run_and_pause script

### DIFF
--- a/playbooks/roles/uu_generic/defaults/main.yml
+++ b/playbooks/roles/uu_generic/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 uu_generic_documentation_link: https://utrechtuniversity.github.io/vre-docs/docs/workspace-catalogue.html
 uu_generic_contact_email: research.engineering@uu.nl
+uu_generic_src_api_endpoint: https://gw.live.surfresearchcloud.nl

--- a/playbooks/roles/uu_generic/tasks/apps.yml
+++ b/playbooks/roles/uu_generic/tasks/apps.yml
@@ -4,3 +4,11 @@
   ansible.builtin.command: snap install codium --classic
   register: uu_generic_install_codium
   changed_when: '"already installed" not in uu_generic_install_codium.stderr'
+
+- name: Install run_and_pause script
+  ansible.builtin.template:
+    src: templates/run_and_pause.sh.j2
+    dest: /usr/local/bin/run_and_pause
+    mode: "0755"
+    owner: "root"
+    group: "root"

--- a/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
+++ b/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 mycommand ..." >&2
+  exit 1
+fi
+
+read -s -p "Please enter your ResearchCloud API token: " token
+echo
+
+
+COMMAND="$*"
+WORKSPACE="{{ fact_workspace_info['workspace_id'] }}"
+ENDPOINT_URL="{{ uu_generic_src_api_endpoint }}/v1/workspace/workspaces/$WORKSPACE"
+PAUSE_COMMAND="curl -X 'POST' \
+  '$ENDPOINT_URL/actions/pause/' \
+  -H 'accept: application/json;Compute' \
+  -H 'authorization: $token' \
+  -H 'Content-Type: application/json;pause' \
+  -d '{}'
+"
+
+echo "Testing whether you are authorized to pause this workspace..."
+result=$(curl -X "GET" "$ENDPOINT_URL/" \
+            -H "accept: application/json;Compute" \
+            -H "authorization: $token" \
+            2> /dev/null
+            )
+trap "Could not login to the ReserachCloud API with your token." ERR
+
+if [[ $(echo "$result" | jq '.allowed_actions | any(. == "pause")' ) == "true" ]]; then
+    echo "You are allowed to pause this workspace. Continuing..."
+else
+    echo "You are NOT allowed to pause this workspace. Stopping..."
+    exit 100
+fi
+
+echo $PAUSE_COMMAND
+
+TMUX_SESSION="run_and_pause$(date '+%d%m%Y%H%M%S')"
+
+echo "Will run the following command, and pause the workspace when it exits:"
+echo "$COMMAND"
+echo
+echo "The command will be ran using tmux. You can exit the tmux window using"
+echo "To re-attach to the window later, use:"
+echo "tmux attach-session -t $TMUX_SESSION"
+echo
+read -p "Press any key to continue... " -n1 -s
+
+FULL_COMMAND="$COMMAND; $PAUSE_COMMAND; bash"
+echo $FULL_COMMAND
+
+tmux new-session -s "$TMUX_SESSION" "$FULL_COMMAND"

--- a/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
+++ b/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
@@ -44,7 +44,7 @@ echo "Will run the following command, and pause the workspace when it exits:"
 echo "$COMMAND"
 echo
 echo "The command will be ran using tmux. You can exit the tmux window using"
-echo "To re-attach to the window later, use:"
+echo "To re-attach to the window later, use this keybinding: 'Control-b d'"
 echo "tmux attach-session -t $TMUX_SESSION"
 echo
 read -p "Press any key to continue... " -n1 -s

--- a/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
+++ b/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+echo "Hello! This script is currently in beta. Please report any issues to UU Research Engineering."
+
 if [ "$#" -lt 1 ]; then
   echo "Usage: $0 mycommand ..." >&2
   exit 1
@@ -41,8 +43,8 @@ TMUX_SESSION="run_and_pause$(date '+%d%m%Y%H%M%S')"
 echo "Will run the following command, and pause the workspace when it exits:"
 echo "$COMMAND"
 echo
-echo "The command will be ran using tmux. You can exit the tmux window using"
-echo "To re-attach to the window later, use this keybinding: 'Control-b d'"
+echo "The command will be run using tmux. You can exit the tmux window using"
+echo "To reattach to the window later, use this keybinding: 'Control-b d'"
 echo "tmux attach-session -t $TMUX_SESSION"
 echo
 read -p "Press any key to continue... " -n1 -s

--- a/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
+++ b/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
@@ -36,8 +36,6 @@ else
     exit 100
 fi
 
-echo $PAUSE_COMMAND
-
 TMUX_SESSION="run_and_pause$(date '+%d%m%Y%H%M%S')"
 
 echo "Will run the following command, and pause the workspace when it exits:"
@@ -50,6 +48,5 @@ echo
 read -p "Press any key to continue... " -n1 -s
 
 FULL_COMMAND="$COMMAND; $PAUSE_COMMAND; bash"
-echo $FULL_COMMAND
 
 tmux new-session -s "$TMUX_SESSION" "$FULL_COMMAND"


### PR DESCRIPTION
This PR adds a script `/usr/local/bin/run_and_pause` to the `uu_generic` role. This role is included by the `uu-provisioning` component, so the script will be available on all UU Catalog Items.

The purpose of `run_and_pause` is to enable users to run a command and pause the workspace when that command exits. It utilizes the [ResearchCloud API](https://gw.live.surfresearchcloud.nl/v1/workspace/swagger/docs/#/workspaces/workspaces_list) to pause the workspace. The command the user wants to run is run in `tmux`, so the user can also log out of the workspace, and the command will continue running.

The user must manually enter their ResearchCloud API token when running the script. See https://servicedesk.surf.nl/wiki/display/WIKI/SRC+API on how to obtain such a token.

For testing the script, you can take the file `run_and_pause.sh.j2` from this PR and substitute variables on two lines:

```bash
WORKSPACE="{{ fact_workspace_info['workspace_id'] }}" # replace the {{ }} and fill in your workspace's ID, found by running cat /etc/rsc/workspace.json"
ENDPOINT_URL="{{ uu_generic_src_api_endpoint }}/v1/workspace/workspaces/$WORKSPACE" # replace the {{ }} with https://gw.live.surfresearchcloud.nl
```