### PR TITLE
Refactor flask_app playbook and underlying roles

### DIFF
--- a/docs/playbooks/flask_app.md
+++ b/docs/playbooks/flask_app.md
@@ -5,6 +5,11 @@
 
 Serves an arbitrary Flask app, which runs on localhost using uWSGI, using Nginx as a reverse proxy. The Flask app is installed from a public git repository. The role allows easily enabling authentication for your webapp, using SRAM and Single Sign-On.
 
+1. From a public git repo
+1. From PyPi (specifying package name and version)
+1. From a requirements file on the target machine. The main advantages of this mode is that it allows you to specify specific dependencies, and that by committing a requirements file to your playbook's repo, you can use something like Dependabot to keep updating to the latest available version of your app.
+    * **Note**: *when using this mode, you must still set the `flask_app_pip_pkg` variable to the name of the package that contains your app, so the role knows which of the dependencies in the requirements file is the app you want to run!*
+
 ## Requires
 
 - Debian-like OS
@@ -14,49 +19,28 @@ Serves an arbitrary Flask app, which runs on localhost using uWSGI, using Nginx 
 
 The user can define:
 
-1. Which Flask app to install, by providing a URL to the appropriate git repo.
+1. Which Flask app to install, by providing a URL to the appropriate git repo (`flask_app_repo`), or by setting a PyPi package to install (`flask_app_pip_pkg`).
 2. Which version of Python to use.
 3. The location of dependency files, such as `requirements.txt` or `pyproject.toml`, relative to the root of the git repo. These will automatically be installed
 4. Whether authentication should be enabled for the webapp.
 5. A number of more advanced settings described [below](#variables).
 
-The role installs `uv` to ensure the appropriate Python version for the app is present, and to install the dependencies.
-
-## app.py vs wsgi.py
-
-Serving Flask apps with uWSGI is usually done in one of two major ways:
-
-1. Set the `uWSGI` `wsgi-file` option to the location of `app.py`, which contains a callable `app`.
-2. Set the `UWSGI` `module` option to `wsgi:app`, indicating that the file `wsgi.py` in the project contains an `app` callable.
-
-This role will assume the first method is to be used, except when `flask_app_path` is `wsgi.py` -- in that case, it will automatically set the `module` config option to `wsgi:app`.
-
-The user can always modify the `uWSGI` config by setting the `flask_app_uwsgi_config` option (see below).
-
 ## Variables
 
-- `flask_app_name`: String. Name of your application.
-- `flask_app_repo`: String. Url to a public git repository containing your app.
-- `flask_app_version`: String. Git tag or version to use.
-- `flask_app_path`: String. Path to the main `.py` file for your Flask app (often `app.py` or `wsgi.py`), relative to the repository root.
-- `flask_app_requirements`: String. Comma-separated list of paths to requirements file (.txt or .toml) in the repo.
-- `flask_app_env`: String. Environment variables to be added to the environment in which the app is run, e.g. `FOO=bar BAZ=qux`. Default: `''`.
-- `flask_app_auth_sram`: Boolean. Whether to enable SRAM authorization / Single-Sign On authentication. Default: true.
-- `flask_app_auth_basic`: Boolean. Whether to enable http basic authentication. Default: false. If both this option and `flask_app_auth_sram` are enabled, the latter takes precedence.
-- `flask_app_python_version`: String. The version of Python to serve the app with. Default: `3.10`.
-- `flask_app_num_workers`: Integer. Number of processes `uWSGI` should spawn to handle requests for the app. Default: `2`.
-- `flask_app_uwsgi_config`: String. Additional multiline `.ini` style configuration for `uWSGI`. See `uWSGI` docs for more info, and see the default `.ini` template in the uWSGI role.
-- `flask_app_location`: String. Nginx location definition determining which URL to serve the app at. Default: `/`, meaning the app is served at `http://yourworkspacefqdn`. Can also be set to e.g. `/myapp` to serve at `http://yourworkspacefqdn/myapp`.
-- `flask_app_username`: String. Optional, used if `flask_app_auth_basic` is enabled to set the username for authentication.
-- `flask_app_password`: String. Optional, used if `flask_app_auth_basic` is enabled to set the password for authentication.
+See the [role documentation](../roles/flask_app.md) for variables that you can set in this playbook, **but note** that the parameters are called differently: where the *role* parameter is called, e.g. `flask_app_pip_pkg`, the parameter for this playbook is called `flask_pip_pkg`.
+
+**Note**: while individual uWSGI settings have their own variable, you can always use `flask_uwsgi_config_block` to add arbitary settings:
+
+* `flask_uwsgi_config_block`: String. Pass in arbitary `key = value` settings with explicit newlines, e.g. `foo = bar\nbar = foo`.
 
 ## See also
 
-- Role [nginx-reverse_proxy](../roles/nginx_reverse_proxy.md)
-- Role [nginx-uwsgi](../roles/nginx_uwsgi.md)
+- Role [flask_app](../roles/flask_app.md)
+- Role [nginx_reverse_proxy](../roles/nginx_reverse_proxy.md)
+- Role [nginx_uwsgi](../roles/nginx_uwsgi.md)
 - Role [require_src_nginx](../roles/require_src_nginx.md)
 
 ## History
-2024 Written by Dawa Ometto (Utrecht University)
+2024-2025 Written by Dawa Ometto (Utrecht University)
 
 [back to index](../index.md#Roles)

--- a/docs/playbooks/flask_app.md
+++ b/docs/playbooks/flask_app.md
@@ -54,6 +54,7 @@ The user can always modify the `uWSGI` config by setting the `flask_app_uwsgi_co
 
 - Role [nginx-reverse_proxy](../roles/nginx_reverse_proxy.md)
 - Role [nginx-uwsgi](../roles/nginx_uwsgi.md)
+- Role [require_src_nginx](../roles/require_src_nginx.md)
 
 ## History
 2024 Written by Dawa Ometto (Utrecht University)

--- a/docs/playbooks/reverse_proxy.md
+++ b/docs/playbooks/reverse_proxy.md
@@ -59,7 +59,8 @@ If one of the `htpasswd` files defined in `reverse_proxy_locations` is not found
 
 ## See also
 
-Role [nginx_reverse_proxy](../roles/nginx_reverse_proxy.md)
+- Role [nginx_reverse_proxy](../roles/nginx_reverse_proxy.md)
+- Role [require_src_nginx](../roles/require_src_nginx.md)
 
 ## History
 2024 Written by Dawa Ometto (Utrecht University)

--- a/docs/roles/flask_app.md
+++ b/docs/roles/flask_app.md
@@ -1,0 +1,76 @@
+# Role flask_app
+[back to index](../index.md#Playbooks)
+
+## Summary
+
+Serves an arbitrary Flask app, which runs on localhost using uWSGI, using Nginx as a reverse proxy. The Flask app is installed either from a public git repository, or from PyPi. The role allows easily enabling authentication for your webapp, using SRAM and Single Sign-On.
+
+The role allows installing the app in the different ways:
+
+1. From a public git repo
+1. From PyPi (specifying package name and version)
+1. From a requirements file on the target machine. The main advantages of this mode is that it allows you to specify specific dependencies, and that by committing a requirements file to your playbook's repo, you can use something like Dependabot to keep updating to the latest available version of your app.
+    * **Note**: *when using this mode, you must still set the `flask_app_pip_pkg` variable to the name of the package that contains your app, so the role knows which of the dependencies in the requirements file is the app you want to run!*
+
+## Requires
+
+- Debian-like OS
+- Nginx web server (installed via the SRC-Nginx component)
+
+## Description
+
+The user can define:
+
+1. Which Flask app to install, by either:
+  * setting a URL to the appropriate git repo.
+  * setting a PyPi package name
+2. Which version of Python to use.
+3. The location of dependency files, such as `requirements.txt` or `pyproject.toml`, relative to the root of the git repo. These will automatically be installed
+4. Whether authentication should be enabled for the webapp.
+5. A number of more advanced settings described [below](#variables).
+
+The role installs `uv` to ensure the appropriate Python version for the app is present, and to install the dependencies.
+
+## app.py vs wsgi.py
+
+Serving Flask apps with uWSGI is usually done in one of two major ways:
+
+1. Set the `uWSGI` `wsgi-file` option to the location of `app.py`, which contains a callable `app`.
+2. Set the `UWSGI` `module` option to `wsgi:app`, indicating that the file `wsgi.py` in the project contains an `app` callable.
+
+This role will assume the first method is to be used, except when `flask_app_module_path` is `wsgi.py` -- in that case, it will automatically set the `module` config option to `wsgi:app`.
+
+The user can always modify the `uWSGI` config by setting the `flask_app_uwsgi_config` option (see below).
+
+## Variables
+
+Many of the variables below are to configure the uWSGI settings. While individual settings have their own variable, note that you can always use either `flask_app_uwsgi_config` (pass in a dict) or `flask_app_uwsgi_config_block` (pass in a string) to configure arbitrary settings.
+
+- `flask_app_name`: String. Name of your application. This is descriptive: it determines, for instance, the directory under which files will be saved (e.g. `/var/www/myappname`). Default: `FlaskApp`.
+- `flask_app_pip_pkg`: String. Name of the PyPi package that contains the app. You must set *either* this variable, *or* `flask_app_repo` (but not both).
+- `flask_app_repo`: String. Url to a public git repository containing your app. You must set *either* this variable, *or* `flask_app_pip_pkg` (but not both).
+- `flask_app_version`: String. Git tag or version to use.
+- `flask_app_module_path`: String. Path to the main `.py` file for your Flask app (often `app.py` or `wsgi.py`), relative to the repository root.
+- `flask_app_pip_requirements`: String. Comma-separated list of paths to requirements file (.txt or .toml), the contents of which will be installed in the venv. When using `flask_app_pip_pkg`, this will be assumed to be a file on the target machine. When using `flask_app_repo`, it will be assumed to be a path inside the specified repository.
+- `flask_app_uwsgi_env`: String. Environment variables to be added to the environment in which the app is run, e.g. `FOO=bar BAZ=qux`. Default: `''`.
+- `flask_app_python_version`: String. The version of Python to serve the app with. Default: `3.10`.
+- `flask_app_num_workers`: Integer. Number of processes `uWSGI` should spawn to handle requests for the app. Default: `2`.
+- `flask_app_uwsgi_config`: Dict. Settings to be added to the `uWSGI` `.ini` config file, according to `key=value`.
+- `flask_app_uwsgi_config_block`: String. Additional multiline `.ini` style configuration for `uWSGI`. See `uWSGI` docs for more info, and see the default `.ini` template in the uWSGI role.
+- `flask_app_chdir`: Boolean. If `true`, the app will be executed from the directory containing the app's code.
+- `flask_app_proxy_auth`: String. Set to `sram` to enable SRAM authorization / Single-Sign On authentication, `basic` for HTTP basic auth, or omit for no authentication. Default: `sram`.
+- `flask_app_proxy_location`: String. Nginx location definition determining which URL to serve the app at. Default: `/`, meaning the app is served at `http://yourworkspacefqdn`. Can also be set to e.g. `/myapp` to serve at `http://yourworkspacefqdn/myapp`.
+- `flask_app_http_username`: String. Optional, used if `flask_app_proxy_auth_basic` is enabled to set the username for authentication.
+- `flask_app_http_password`: String. Optional, used if `flask_app_proxy_auth_basic` is enabled to set the password for authentication.
+
+## See also
+
+- Playbook [flask_app](../playbooks/flask_app.md)
+- Role [nginx_reverse_proxy](../roles/nginx_reverse_proxy.md)
+- Role [nginx_uwsgi](../roles/nginx_uwsgi.md)
+- Role [require_src_nginx](../roles/require_src_nginx.md)
+
+## History
+2024-2025 Written by Dawa Ometto (Utrecht University)
+
+[back to index](../index.md#Roles)

--- a/docs/roles/nginx_uwsgi.md
+++ b/docs/roles/nginx_uwsgi.md
@@ -39,6 +39,7 @@ The nginx web server is used as a reverse proxy, using the [reverse_proxy](./ngi
 - `uwsgi_num_workers`: Integer. The number of workers `uwsgi` should spawn to handle requests for this app. Default: 2.
 - `uwsgi_venv`: String. To use a preexisting installation of `uwsgi` in a venv (rather than using the system-provided `uwsgi`), set this to the path to the root of the `venv`. Default: `''`.
 - `uwsgi_proxy_config`: Dict. Options to be passed to the [reverse proxy role](./nginx_reverse_proxy.md), in addition to the default location and `uwsgi_pass` settings. Example: `{ auth: 'sram' }`. Default: empty.
+- `uwsgi_config_dir`: String. Set the directory in which the `.pid` and `.ini` file should be saved. Default: `uwsgi_app_dir`.
 - `uwsgi_config`: Dict. Key/value pairs that will be translated to `uwsgi` settings added to the application's `.ini` file. Example: `{ callable: 'foobar' }` (see `uwsgi`'s docs for options). Default: empty.
 - `uwsgi_config_block`: String. Multiline .ini style key/value pairs to be added to the application's `.ini` file.
 

--- a/docs/roles/nginx_uwsgi.md
+++ b/docs/roles/nginx_uwsgi.md
@@ -41,6 +41,7 @@ The nginx web server is used as a reverse proxy, using the [reverse_proxy](./ngi
 - `uwsgi_proxy_config`: Dict. Options to be passed to the [reverse proxy role](./nginx_reverse_proxy.md), in addition to the default location and `uwsgi_pass` settings. Example: `{ auth: 'sram' }`. Default: empty.
 - `uwsgi_config_dir`: String. Set the directory in which the `.pid` and `.ini` file should be saved. Default: `uwsgi_app_dir`.
 - `uwsgi_config`: Dict. Key/value pairs that will be translated to `uwsgi` settings added to the application's `.ini` file. Example: `{ callable: 'foobar' }` (see `uwsgi`'s docs for options). Default: empty.
+- `uwsgi_chdir`: String. Working directory which should be used to execute the app. Default: `uwsgi_app_dir`. Will be skipped if set to an empty string.
 - `uwsgi_config_block`: String. Multiline .ini style key/value pairs to be added to the application's `.ini` file.
 
 ## See also

--- a/docs/roles/require_src_nginx.md
+++ b/docs/roles/require_src_nginx.md
@@ -1,0 +1,13 @@
+# Role require_src_nginx
+[back to index](../index.md#Roles)
+
+## Summary
+
+A simple role that applies some heuristics to determine if the [SRC-Nginx component](https://gitlab.com/rsc-surf-nl/plugins/plugin-nginx) is installed, and Nginx is active. If not, this role will fail and exit the playbook with a message to the user explaining that SRC-Nginx is required.
+
+This is useful for roles that depend on the specific Nginx configuration provided by that component: for instance, the [nginx_reverse_proxy](./nginx_reverse_proxy.md) role relies on the presence of the configuration that allows for SRAM authentication.
+
+## History
+2025 Written by Dawa Ometto (Utrecht University)
+
+[back to index](../index.md#Roles)

--- a/docs/roles/uv.md
+++ b/docs/roles/uv.md
@@ -28,12 +28,14 @@ uv_python_paths: {
 
 - `uv_vens`: List of dicts describing virtual environments to be initialized with `uv`. Each item in the dict is expected to contain a `python` and `path` attribute: the former determines which Python verison to use for the venv, while the latter is the location of the venv. Example: `{ path: '/tmp/foo', python: '3.11' }`. __Note__: Python versions are installed if necessary.
 - `uv_python_versions`: List of strings of python versions to be installed with `uv`. For example: `[ '3.11', '3.12.3' ]`.
+- `uv_become`: Boolean. Whether to excute UV tasks (installation of Python versions and creation of venvs) as a different (non-root) user. Default: `false`.
+- `uv_become_user`: String. If `uv_become` is set to `true`, which user should the tasks be executed as? E.g. `www-data`. Default: `root`.
 
 ## See also
 
 - [pipx_install_systemwide role](./pipx_install_systemwide.md)
 
 ## History
-2024 Written by Dawa Ometto (Utrecht University)
+2024-2025 Written by Dawa Ometto (Utrecht University)
 
 [back to index](../index.md#Roles)

--- a/molecule/playbook-flask_app/molecule.yml
+++ b/molecule/playbook-flask_app/molecule.yml
@@ -22,13 +22,14 @@ provisioner:
         - name: flask_app
           path: flask_app.yml
           parameters:
-            flask_app_name: hello
-            flask_app_path: hello/app.py
-            flask_app_auth_basic: true
-            flask_app_username: tester
-            flask_app_password: letmein
-            flask_app_repo: https://github.com/dometto/flask-examples.git
-            flask_app_requirements: 'requirements.txt'
-            flask_app_location: '/'
-            flask_app_uwsgi_config: >
-              vacuum = false # just to test the flask_app_uswgi_config option
+            flask_name: hello
+            flask_module_path: hello/app.py
+            flask_proxy_auth: basic
+            flask_uwsgi_env: "MY_ENV1=foo MY_ENV2=bar"
+            flask_http_username: tester
+            flask_http_password: letmein
+            flask_repo: https://github.com/UtrechtUniversity/flask-examples.git
+            flask_pip_requirements: 'requirements.txt'
+            flask_proxy_location: '/'
+            flask_uwsgi_config_block: >
+              vacuum = false # just to test the flask_app_uswgi_config_block option

--- a/molecule/playbook-flask_app/verify.yml
+++ b/molecule/playbook-flask_app/verify.yml
@@ -12,7 +12,27 @@
         url_password: letmein
       register: flask_app_curl_result
 
-    - name: Assert testusers have correct groups and gids
+    - name: Get systemd definition contents
+      ansible.builtin.slurp:
+        src: /etc/systemd/system/uwsgi-hello.service
+      register: slurp_service
+
+    - name: Get the systemd definition 
+      ansible.builtin.set_fact:
+        systemd_definition: "{{ slurp_service['content'] | b64decode }}"
+
+    - name: Get .ini file contents
+      ansible.builtin.slurp:
+        src: /var/www/hello/hello.ini
+      register: slurp_ini
+
+    - name: Get .ini contents 
+      ansible.builtin.set_fact:
+        ini_file: "{{ slurp_ini['content'] | b64decode }}"
+
+    - name: Assertions
       ansible.builtin.assert:
         that:
           - '"Hello, World" in flask_app_curl_result.content'
+          - '"MY_ENV2=bar" in systemd_definition'
+          - '"vacuum = false" in ini_file'

--- a/playbooks/flask_app.yml
+++ b/playbooks/flask_app.yml
@@ -3,115 +3,21 @@
   hosts: localhost
   gather_facts: true
   vars:
-    _flask_app_auth_sram: "{{ flask_app_auth_sram | default(false, true) | bool | ternary('sram', '') }}"
-    _flask_app_auth_basic: "{{ flask_app_auth_basic | default(false, true) | bool | ternary('basic', '') }}"
-    flask_app_auth: "{{ _flask_app_auth_sram | ternary(_flask_app_auth_sram, _flask_app_auth_basic) }}"
-    flask_app_python_version: "3.10"
-    uwsgi_app_name: "{{ flask_app_name }}"
-    uwsgi_app_path: "{{ flask_app_path }}"
-    uwsgi_app_dir: /var/www/{{ flask_app_name }}
-    uwsgi_app_env: "{{ dict( ( flask_app_env | default('') ).split() | map('regex_search', '.+=.+') | select | map('split', '=') ) }}"
-    uwsgi_num_workers: "{{ flask_app_num_workers | default('2', true) }}"
-    _uwsgi_config:
-      callable: app
-      module: "{{ (flask_app_name == 'wsgi.py') | ternary('wsgi:app', omit) }}"
-    uwsgi_config_block: "{{ flask_app_uwsgi_config | default('') | replace('\\n', '\n') }}"
-    uwsgi_venv: /var/www/{{ flask_app_name }}/venv
-    uwsgi_nginx_mountpoint: "{{ flask_app_location | default('/', true) }}"
-    _uwsgi_proxy_config:
-      auth: "{{ flask_app_auth | default(omit, true) }}"
-      htpasswd: "{{ (flask_app_auth == 'basic') | ternary(flask_app_name, omit) }}"
-    nginx_reverse_proxy_auth_info: "{{ _flask_app_auth_info }}"
-
-  pre_tasks:
-    - name: Check if nginx is installed
-      when: "'molecule-notest' not in ansible_skip_tags"
-      block:
-        - name: Populate service facts
-          ansible.builtin.service_facts:
-
-        - name: Stop if nginx is not installed
-          ansible.builtin.fail:
-            msg: Nginx must be installed and active for this component to work.
-          when: services['nginx.service'].state != 'running'
-
-    - name: Check for presence of SRC Nginx SRAM authentication config
-      ansible.builtin.lineinfile:
-        line: "{{ item }}"
-        dest: /etc/nginx/app-location-conf.d/authentication.conf
-      check_mode: true
-      register: src_nginx_config
-      with_items:
-        - location @custom_401 {
-        - location = /oauth2_callback {
-        - location = /validate {
-
-    - name: Stop if SRC nginx config is not present
-      ansible.builtin.fail:
-        msg: The SRC-Nginx component must be run before this component
-      when: src_nginx_config.changed
-
-    - name: Resolve 'omit' in variables
-      block:
-        - name: Set uwsgi_config
-          ansible.builtin.set_fact:
-            uwsgi_config: "{{ _uwsgi_config }}"
-
-        - name: Set uwsgi_proxy_config
-          ansible.builtin.set_fact:
-            uwsgi_proxy_config: "{{ _uwsgi_proxy_config }}"
-
-    - name: Set auth info variable if auth basic is set
-      when: flask_app_auth == 'basic'
-      ansible.builtin.set_fact:
-        _flask_app_auth_info:
-          - name: "{{ flask_app_name }}"
-            username: "{{ flask_app_username | default('') }}"
-            password: "{{ flask_app_password | default('') }}"
-      no_log: true
-
-    - name: Clone repo
-      tags: molecule-idempotence-notest
-      ansible.builtin.git:
-        repo: "{{ flask_app_repo }}"
-        version: "{{ flask_app_version | default(omit, true) }}"
-        dest: "{{ uwsgi_app_dir }}"
-        depth: 1
-
-    - name: Create venv with uv
-      ansible.builtin.include_role:
-        name: uv
-      vars:
-        uv_venvs:
-          - path: "{{ uwsgi_venv }}"
-            python: "{{ flask_app_python_version }}"
-
-    - name: Ensure build requirements for uwsgi present
-      when: ansible_os_family == 'Debian'
-      ansible.builtin.package:
-        name:
-          - build-essential
-          - python3-dev
-
-    - name: Install uwsgi
-      ansible.builtin.pip:
-        executable: uv_pip
-        name:
-          - wheel
-          - uwsgi
-      environment:
-        VIRTUAL_ENV: "{{ uwsgi_venv }}"
-        CC: gcc # https://github.com/astral-sh/uv/issues/6488
-        LIBRARY_PATH: "{{ uv_python_paths[flask_app_python_version] | regex_replace('/bin/python3?', '/lib/') }}"
-
-    - name: Install requirements
-      when: flask_app_requirements | length > 0
-      ansible.builtin.pip:
-        executable: uv_pip
-        requirements: "{{ uwsgi_app_dir }}/{{ item | trim }}"
-      environment:
-        VIRTUAL_ENV: "{{ uwsgi_venv }}"
-      with_items: "{{ flask_app_requirements.split(',') }}"
-
+    flask_app_repo: "{{ flask_repo | default('', true) }}"
+    flask_app_pip_pkg: "{{ flask_pip_pkg | default('', true) }}"
+    flask_app_pip_requirements: "{{ flask_pip_requirements | default('', true) }}"
+    flask_app_version: "{{ flask_pip_version | default('', true) }}"
+    flask_app_name: "{{ flask_name | default('FlaskApp', true) }}"
+    flask_app_num_workers: "{{ flask_num_workers | default('2', true) }}"
+    flask_app_python_version: "{{ flask_python_version | default('3.10', true) }}"
+    flask_app_module_path: "{{ flask_module_path | default('app.py', true) }}"
+    flask_app_http_username: "{{ flask_http_username | default('', true) }}"
+    flask_app_http_password: "{{ flask_http_password | default('', true) }}"
+    flask_app_proxy_auth: "{{ flask_proxy_auth | default('sram', true) }}"
+    flask_app_location: "{{ flask_proxy_location | default('/', true) }}"
+    flask_app_uwsgi_env: "{{ dict( ( flask_uwsgi_env | default('') ).split(' ') | map('regex_search', '.+=.+') | select | map('split', '=')) }}" # String -> dict
+    flask_app_uwsgi_config_block: "{{ flask_uwsgi_config_block | default('') | replace('\\n', '\n') }}"
+    flask_app_chdir: "{{ flask_chdir | default(true, true) }}"
   roles:
-    - role: nginx_uwsgi
+    - role: require_src_nginx
+    - role: flask_app

--- a/playbooks/reverse_proxy.yml
+++ b/playbooks/reverse_proxy.yml
@@ -4,32 +4,9 @@
   gather_facts: true
 
   pre_tasks:
-    - name: Check if nginx is installed
-      when: "'molecule-notest' not in ansible_skip_tags"
-      block:
-        - name: Populate service facts
-          ansible.builtin.service_facts:
-
-        - name: Stop if nginx is not installed
-          ansible.builtin.fail:
-            msg: Nginx must be installed and active for this component to work.
-          when: services['nginx.service'].state != 'running'
-
-    - name: Check for presence of SRC Nginx SRAM authentication config
-      ansible.builtin.lineinfile:
-        line: "{{ item }}"
-        dest: /etc/nginx/app-location-conf.d/authentication.conf
-      check_mode: true
-      register: src_nginx_config
-      with_items:
-        - location @custom_401 {
-        - location = /oauth2_callback {
-        - location = /validate {
-
-    - name: Stop if SRC nginx config is not present
-      ansible.builtin.fail:
-        msg: The SRC-Nginx component must be run before this component
-      when: src_nginx_config.changed
+    - name: Ensure SRC-Nginx is present
+      ansible.builtin.include_role:
+        name: require_src_nginx
 
     - name: Parse reverse proxy locations variable as yaml
       ansible.builtin.set_fact:

--- a/playbooks/roles/flask_app/defaults/main.yml
+++ b/playbooks/roles/flask_app/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+flask_app_repo: ""
+flask_app_pip_pkg: ""
+flask_app_version: ""
+flask_app_name: FlaskApp
+flask_app_num_workers: 2
+flask_app_uwsgi_env: {}
+flask_app_python_version: "3.10"
+flask_app_module_path: app.py
+flask_app_http_username: "" # http basic username
+flask_app_http_password: "" # http basic password
+flask_app_proxy_auth: sram
+flask_app_uwsgi_config:
+  callable: app
+  module: "{{ (flask_app_module_path == 'wsgi.py') | ternary('wsgi:app', omit) }}"
+flask_app_uwsgi_config_block: ""
+flask_app_proxy_location: / # nginx location
+flask_app_proxy_config:
+  auth: "{{ flask_app_proxy_auth | default(omit, true) }}"
+  htpasswd: "{{ (flask_app_proxy_auth == 'basic') | ternary(flask_app_name, omit) }}"
+flask_app_chdir: true
+flask_app_pip_requirements: ""

--- a/playbooks/roles/flask_app/meta/main.yml
+++ b/playbooks/roles/flask_app/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Dawa Ometto (Utrecht University)
+  description: Setup flask application with Nginx reverse proxy.
+  license: GPLv3
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all

--- a/playbooks/roles/flask_app/molecule/app_from_pip/converge.yml
+++ b/playbooks/roles/flask_app/molecule/app_from_pip/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  roles:
+    - role: flask_app
+      vars:
+        flask_app_pip_pkg: asreview
+        flask_app_version: 1.6
+        flask_app_module_path: webapp/app.py
+        flask_app_python_version: 3.11
+        flask_app_name: example
+        flask_app_proxy_auth: basic
+        flask_app_http_username: tester
+        flask_app_http_password: letmein
+        flask_app_uwsgi_config:
+          module: asreview.webapp.app:create_app()
+        flask_app_chdir: false
+        flask_app_uwsgi_env:
+          ASREVIEW_PATH: /var/www/example/asreview

--- a/playbooks/roles/flask_app/molecule/app_from_pip/molecule.yml
+++ b/playbooks/roles/flask_app/molecule/app_from_pip/molecule.yml
@@ -1,0 +1,22 @@
+---
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ./converge.yml
+    prepare: ./prepare.yml
+  env:
+    ANSIBLE_ROLES_PATH: ../../../
+  config_options:
+    defaults:
+      remote_tmp: /tmp
+role_name_check: 1
+platforms:
+  - name: workspace-src-ubuntu_jammy
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy-nginx
+    command: /sbin/init
+    pre_build_image: true
+    registry:
+      url: $DOCKER_REGISTRY
+      credentials:
+        username: $DOCKER_USER
+        password: $DOCKER_PW

--- a/playbooks/roles/flask_app/molecule/app_from_pip/prepare.yml
+++ b/playbooks/roles/flask_app/molecule/app_from_pip/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true

--- a/playbooks/roles/flask_app/molecule/app_from_pip/verify.yml
+++ b/playbooks/roles/flask_app/molecule/app_from_pip/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Test uswgi app
+      ansible.builtin.uri:
+        url: http://127.0.0.1/
+        method: GET
+        return_content: true
+        url_username: tester
+        url_password: letmein
+      register: uwsgi_curl_result
+
+    - name: Assert content correct
+      ansible.builtin.assert:
+        that:
+          - '"ASReview" in uwsgi_curl_result.content'

--- a/playbooks/roles/flask_app/molecule/app_from_requirements/converge.yml
+++ b/playbooks/roles/flask_app/molecule/app_from_requirements/converge.yml
@@ -1,0 +1,20 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  roles:
+    - role: flask_app
+      vars:
+        flask_app_pip_requirements: /tmp/requirements.txt # set the requirements file to install the app from
+        flask_app_pip_pkg: asreview # specify which package from the requirements file is the actual app
+        flask_app_module_path: webapp/app.py
+        flask_app_python_version: 3.11
+        flask_app_name: example
+        flask_app_proxy_auth: basic
+        flask_app_http_username: tester
+        flask_app_http_password: letmein
+        flask_app_uwsgi_config:
+          module: asreview.webapp.app:create_app()
+        flask_app_chdir: false
+        flask_app_uwsgi_env:
+          ASREVIEW_PATH: /var/www/example/asreview

--- a/playbooks/roles/flask_app/molecule/app_from_requirements/molecule.yml
+++ b/playbooks/roles/flask_app/molecule/app_from_requirements/molecule.yml
@@ -1,0 +1,22 @@
+---
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ./converge.yml
+    prepare: ./prepare.yml
+  env:
+    ANSIBLE_ROLES_PATH: ../../../
+  config_options:
+    defaults:
+      remote_tmp: /tmp
+role_name_check: 1
+platforms:
+  - name: workspace-src-ubuntu_jammy
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy-nginx
+    command: /sbin/init
+    pre_build_image: true
+    registry:
+      url: $DOCKER_REGISTRY
+      credentials:
+        username: $DOCKER_USER
+        password: $DOCKER_PW

--- a/playbooks/roles/flask_app/molecule/app_from_requirements/prepare.yml
+++ b/playbooks/roles/flask_app/molecule/app_from_requirements/prepare.yml
@@ -1,0 +1,16 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true
+
+    - name: Create requirements file
+      ansible.builtin.copy:
+        dest: /tmp/requirements.txt
+        content: asreview
+        mode: "0755"
+        owner: root
+        group: root

--- a/playbooks/roles/flask_app/molecule/app_from_requirements/verify.yml
+++ b/playbooks/roles/flask_app/molecule/app_from_requirements/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Test uswgi app
+      ansible.builtin.uri:
+        url: http://127.0.0.1/
+        method: GET
+        return_content: true
+        url_username: tester
+        url_password: letmein
+      register: uwsgi_curl_result
+
+    - name: Assert content correct
+      ansible.builtin.assert:
+        that:
+          - '"ASReview" in uwsgi_curl_result.content'

--- a/playbooks/roles/flask_app/molecule/default/converge.yml
+++ b/playbooks/roles/flask_app/molecule/default/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  roles:
+    - role: flask_app
+      vars:
+        flask_app_repo: https://github.com/UtrechtUniversity/flask-examples.git # Use app from git
+        flask_app_pip_requirements: requirements.txt
+        flask_app_name: example
+        flask_app_module_path: hello/app.py
+        flask_app_config:
+          callable: app
+        flask_app_proxy_auth: basic
+        flask_app_proxy_location: /
+        flask_app_http_username: tester
+        flask_app_http_password: letmein

--- a/playbooks/roles/flask_app/molecule/default/molecule.yml
+++ b/playbooks/roles/flask_app/molecule/default/molecule.yml
@@ -1,0 +1,22 @@
+---
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ./converge.yml
+    prepare: ./prepare.yml
+  env:
+    ANSIBLE_ROLES_PATH: ../../../
+  config_options:
+    defaults:
+      remote_tmp: /tmp
+role_name_check: 1
+platforms:
+  - name: workspace-src-ubuntu_jammy
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy-nginx
+    command: /sbin/init
+    pre_build_image: true
+    registry:
+      url: $DOCKER_REGISTRY
+      credentials:
+        username: $DOCKER_USER
+        password: $DOCKER_PW

--- a/playbooks/roles/flask_app/molecule/default/prepare.yml
+++ b/playbooks/roles/flask_app/molecule/default/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: Prepare
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Update apt cache
+      ansible.builtin.apt:
+        update_cache: true

--- a/playbooks/roles/flask_app/molecule/default/verify.yml
+++ b/playbooks/roles/flask_app/molecule/default/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+
+    - name: Test uswgi app
+      ansible.builtin.uri:
+        url: http://127.0.0.1/
+        method: GET
+        return_content: true
+        url_username: tester
+        url_password: letmein
+      register: uwsgi_curl_result
+
+    - name: Assert content correct
+      ansible.builtin.assert:
+        that:
+          - '"Hello, World" in uwsgi_curl_result.content'

--- a/playbooks/roles/flask_app/tasks/debian.yml
+++ b/playbooks/roles/flask_app/tasks/debian.yml
@@ -1,0 +1,6 @@
+---
+- name: Ensure build requirements for uwsgi present
+  ansible.builtin.package:
+    name:
+      - build-essential
+      - python3-dev

--- a/playbooks/roles/flask_app/tasks/main.yml
+++ b/playbooks/roles/flask_app/tasks/main.yml
@@ -1,0 +1,140 @@
+---
+- name: Ensure either the name of a pip package or a git repo is set
+  when: not (flask_app_pip_pkg_defined or flask_app_repo_defined)
+  ansible.builtin.fail:
+    msg: "You must set either flask_app_pip_pkg (to install the flask app as a pip package or from a requirements file), or flask_app_repo (to clone the app from a git repo)."
+
+- name: Set permissions on /var/www
+  ansible.builtin.file:
+    dest: /var/www
+    owner: root
+    group: "{{ flask_app_webserver_user }}"
+    mode: "0770"
+
+- name: Create base dir
+  ansible.builtin.file:
+    dest: "{{ flask_app_base_dir }}"
+    state: directory
+    owner: "{{ flask_app_webserver_user }}"
+    group: "{{ flask_app_webserver_user }}"
+    mode: "0750"
+
+- name: Create venv with uv
+  ansible.builtin.include_role:
+    name: uv
+  vars:
+    uv_become: true
+    uv_become_user: "{{ flask_app_webserver_user }}"
+    uv_venvs:
+      - path: "{{ flask_app_venv }}"
+        python: "{{ flask_app_python_version }}"
+
+- name: Set venv library path
+  ansible.builtin.set_fact:
+    flask_app_venv_lib_path: "{{ uv_python_paths[flask_app_python_version] | regex_replace('/bin/python.*', '/lib/') }}"
+
+- name: Set app directory path
+  ansible.builtin.set_fact:
+    flask_app_dir: "{{ flask_app_pip_pkg | ternary(flask_app_pip_pkg_location, flask_app_base_dir~'/app') }}"
+
+- name: Include Debian-family specific tasks
+  ansible.builtin.include_tasks: debian.yml
+  when: ansible_os_family == 'Debian'
+
+- name: Install uwsgi from pip
+  become: true
+  become_user: "{{ flask_app_webserver_user }}"
+  ansible.builtin.pip:
+    executable: uv_pip
+    name:
+      - wheel
+      - uwsgi
+  environment:
+    VIRTUAL_ENV: "{{ flask_app_venv }}"
+    CC: gcc # https://github.com/astral-sh/uv/issues/6488
+    LIBRARY_PATH: "{{ flask_app_venv_lib_path }}"
+
+- name: Install the desired app from PyPi
+  become: true
+  become_user: "{{ flask_app_webserver_user }}"
+  when: not flask_app_repo_defined
+  block:
+
+    - name: Install the desired app from PypI
+      when: not flask_app_pip_requirements_defined
+      ansible.builtin.pip:
+        executable: uv_pip
+        name: "{{ flask_app_pip_pkg }}{{ flask_app_version_str }}"
+      environment:
+        VIRTUAL_ENV: "{{ flask_app_venv }}"
+        CC: gcc # https://github.com/astral-sh/uv/issues/6488
+        LIBRARY_PATH: "{{ flask_app_venv_lib_path }}"
+
+    - name: Install the app or dependencies from a requirements file
+      when: flask_app_pip_requirements_defined
+      ansible.builtin.pip:
+        executable: uv_pip
+        requirements: "{{ flask_app_pip_requirements }}"
+      environment:
+        VIRTUAL_ENV: "{{ flask_app_venv }}"
+        CC: gcc # https://github.com/astral-sh/uv/issues/6488
+        LIBRARY_PATH: "{{ flask_app_venv_lib_path }}"
+
+- name: Install the desired app from git
+  become: true
+  become_user: "{{ flask_app_webserver_user }}"
+  tags: molecule-idempotence-notest
+  when: flask_app_repo_defined
+  block:
+    - name: Clone git repo
+      ansible.builtin.git:
+        repo: "{{ flask_app_repo }}"
+        version: "{{ flask_app_version | default(omit, true) }}"
+        dest: "{{ flask_app_dir }}"
+        depth: 1
+
+    - name: Install requirements
+      when: flask_app_pip_requirements
+      ansible.builtin.pip:
+        executable: uv_pip
+        requirements: "{{ flask_app_dir }}/{{ item | trim }}"
+      environment:
+        VIRTUAL_ENV: "{{ flask_app_venv }}"
+      with_items: "{{ flask_app_pip_requirements.split(',') }}"
+
+- name: Set variable facts
+  block:
+
+    - name: Set auth info variable for reverse proxy role if auth basic is set
+      when: flask_app_proxy_auth == 'basic'
+      ansible.builtin.set_fact:
+        nginx_reverse_proxy_auth_info:
+          - name: "{{ flask_app_name }}"
+            username: "{{ flask_app_http_username }}"
+            password: "{{ flask_app_http_password }}"
+      no_log: true
+
+    - name: Set uwsgi config (resolve omit-placeholders)
+      ansible.builtin.set_fact:
+        _flask_app_uwsgi_config: "{{ flask_app_uwsgi_config }}"
+
+    - name: Set uwsgi proxy config (resolve omit-placeholders)
+      ansible.builtin.set_fact:
+        _flask_app_proxy_config: "{{ flask_app_proxy_config }}"
+
+- name: Include nginx_uwsgi role
+  ansible.builtin.include_role:
+    name: nginx_uwsgi
+  vars:
+    uwsgi_app_name: "{{ flask_app_name }}"
+    uwsgi_app_dir: "{{ flask_app_dir }}"
+    uwsgi_venv: "{{ flask_app_venv }}"
+    uwsgi_app_path: "{{ flask_app_module_path }}"
+    uwsgi_env: "{{ flask_app_uwsgi_env }}"
+    uwsgi_num_workers: "{{ flask_app_num_workers }}"
+    uwsgi_config: "{{ _flask_app_uwsgi_config }}"
+    uwsgi_config_block: "{{ flask_app_uwsgi_config_block }}"
+    uwsgi_config_dir: "{{ flask_app_base_dir }}"
+    uwsgi_chdir: "{{ flask_app_chdir | ternary(flask_app_dir, '') }}"
+    uwsgi_proxy_config: "{{ _flask_app_proxy_config }}"
+    uwsgi_nginx_mountpoint: "{{ flask_app_proxy_location }}"

--- a/playbooks/roles/flask_app/vars/main.yml
+++ b/playbooks/roles/flask_app/vars/main.yml
@@ -1,0 +1,9 @@
+---
+flask_app_base_dir: /var/www/{{ flask_app_name }}
+flask_app_venv: "{{ flask_app_base_dir }}/venv"
+flask_app_pip_pkg_defined: "{{ flask_app_pip_pkg | length > 0 }}"
+flask_app_repo_defined: "{{ flask_app_repo | length > 0 }}"
+flask_app_pip_requirements_defined: "{{ flask_app_pip_requirements | length > 0 }}"
+flask_app_webserver_user: www-data
+flask_app_pip_pkg_location: "{{ flask_app_base_dir }}/venv/lib/python{{ flask_app_python_version }}/site-packages/{{ flask_app_pip_pkg }}"
+flask_app_version_str: "{{ flask_app_version | default('') | string | ternary('~='~flask_app_version, '') }}"

--- a/playbooks/roles/nginx_uwsgi/defaults/main.yml
+++ b/playbooks/roles/nginx_uwsgi/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 uwsgi_app_dir: /var/www/uwsgi
+uwsgi_config_dir: "{{ uwsgi_app_dir }}"
 uwsgi_app_path: app.py
 uwsgi_app_name: example
 uwsgi_plugins: python3

--- a/playbooks/roles/nginx_uwsgi/defaults/main.yml
+++ b/playbooks/roles/nginx_uwsgi/defaults/main.yml
@@ -13,3 +13,4 @@ uwsgi_venv: ""
 uwsgi_proxy_config: {}
 uwsgi_config: {}
 uwsgi_config_block: ""
+uwsgi_chdir: "{{ uwsgi_app_dir }}"

--- a/playbooks/roles/nginx_uwsgi/tasks/main.yml
+++ b/playbooks/roles/nginx_uwsgi/tasks/main.yml
@@ -50,7 +50,7 @@
 - name: Create uwsgi ini file for app
   ansible.builtin.template:
     src: uwsgi-example.ini.j2
-    dest: "{{ uwsgi_app_dir }}/{{ uwsgi_app_name }}.ini"
+    dest: "{{ uwsgi_config_dir }}/{{ uwsgi_app_name }}.ini"
     owner: root
     group: www-data
     mode: "0644"

--- a/playbooks/roles/nginx_uwsgi/templates/uwsgi-example.ini.j2
+++ b/playbooks/roles/nginx_uwsgi/templates/uwsgi-example.ini.j2
@@ -10,7 +10,7 @@ chmod-socket = 660
 vacuum = true
 die-on-term = true
 master = true
-pidfile = {{ uwsgi_app_dir }}/{{ uwsgi_app_name }}.pid
+pidfile = {{ uwsgi_config_dir }}/{{ uwsgi_app_name }}.pid
 {% for key, value in uwsgi_config.items() %}
 {% if value | length > 0 %}
 {{ key }}={{ value }}

--- a/playbooks/roles/nginx_uwsgi/templates/uwsgi-example.ini.j2
+++ b/playbooks/roles/nginx_uwsgi/templates/uwsgi-example.ini.j2
@@ -1,6 +1,8 @@
 [uwsgi]
 plugins = {{ uwsgi_plugins }}
+{% if uwsgi_chdir | length > 0 %}
 chdir = {{ uwsgi_app_dir }}/
+{% endif %}
 workers = {{ uwsgi_num_workers }}
 socket = /tmp/uwsgi-{{ uwsgi_app_name }}.sock
 uid = www-data

--- a/playbooks/roles/nginx_uwsgi/templates/uwsgi.service.j2
+++ b/playbooks/roles/nginx_uwsgi/templates/uwsgi.service.j2
@@ -13,7 +13,7 @@ Environment="{{ var_name }}={{ value }}"
 {% endfor %}
 {% if uwsgi_venv | length > 0 %}
 Environment="PATH={{ uwsgi_venv }}/bin"
-ExecStart={{ uwsgi_venv }}/bin/uwsgi --ini {{ uwsgi_app_dir }}/{{ uwsgi_app_name }}.ini
+ExecStart={{ uwsgi_venv }}/bin/uwsgi --ini {{ uwsgi_config_dir }}/{{ uwsgi_app_name }}.ini
 {% else %}
 ExecStart=/usr/bin/uwsgi --ini {{ uwsgi_app_dir }}/{{ uwsgi_app_name }}.ini
 {% endif %}

--- a/playbooks/roles/nginx_uwsgi/templates/uwsgi.service.j2
+++ b/playbooks/roles/nginx_uwsgi/templates/uwsgi.service.j2
@@ -5,7 +5,9 @@ After=network.target
 [Service]
 User=www-data
 Group=www-data
+{% if uwsgi_chdir | length > 0 %}
 WorkingDirectory={{ uwsgi_app_dir }}
+{% endif %}
 StandardOutput=append:/var/log/uwsgi/{{ uwsgi_app_name }}.log
 StandardError=append:/var/log/uwsgi/{{ uwsgi_app_name }}_err.log
 {% for var_name, value in uwsgi_env.items() %}

--- a/playbooks/roles/require_src_nginx/meta/main.yml
+++ b/playbooks/roles/require_src_nginx/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  author: Dawa Ometto (Utrecht University)
+  description: Check for presence of SRC-Nginx component and fail if not present.
+  license: GPLv3
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Fedora
+      version:
+        - all
+    - name: Debian
+      versions:
+        - all

--- a/playbooks/roles/require_src_nginx/molecule/default/converge.yml
+++ b/playbooks/roles/require_src_nginx/molecule/default/converge.yml
@@ -1,0 +1,28 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  vars:
+    active_platform_has_nginx: "{{ 'nginx' in inventory_hostname }}"
+  tasks:
+    - block:
+        - name: Include role
+          ansible.builtin.include_role:
+            name: require_src_nginx
+          register: role_execution
+        - name: Check execution halted
+          ansible.builtin.fail:
+            msg: Execution should stop before this task when Nginx is not present
+          register: should_not_run
+      rescue:
+        - name: Assert role failed
+          when: not active_platform_has_nginx
+          ansible.builtin.assert:
+            that:
+              - role_execution is defined
+              - should_not_run is not defined
+        - name: Assert role succeeded
+          when: active_platform_has_nginx
+          ansible.builtin.assert:
+            that:
+              - should_not_run is defined

--- a/playbooks/roles/require_src_nginx/molecule/default/converge.yml
+++ b/playbooks/roles/require_src_nginx/molecule/default/converge.yml
@@ -5,7 +5,8 @@
   vars:
     active_platform_has_nginx: "{{ 'nginx' in inventory_hostname }}"
   tasks:
-    - block:
+    - name: Converge
+      block:
         - name: Include role
           ansible.builtin.include_role:
             name: require_src_nginx

--- a/playbooks/roles/require_src_nginx/molecule/default/molecule.yml
+++ b/playbooks/roles/require_src_nginx/molecule/default/molecule.yml
@@ -1,0 +1,43 @@
+---
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ./converge.yml
+  env:
+    ANSIBLE_ROLES_PATH: ../../../
+  config_options:
+    defaults:
+      remote_tmp: /tmp
+role_name_check: 1
+platforms:
+  - name: workspace-src-ubuntu_jammy_nginx
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy-nginx
+    command: /sbin/init
+    pre_build_image: true
+    registry:
+      url: $DOCKER_REGISTRY
+      credentials:
+        username: $DOCKER_USER
+        password: $DOCKER_PW
+  - name: workspace-src-ubuntu_jammy
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy
+    command: /sbin/init
+    pre_build_image: true
+    registry:
+      url: $DOCKER_REGISTRY
+      credentials:
+        username: $DOCKER_USER
+        password: $DOCKER_PW
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/playbooks/roles/require_src_nginx/tasks/main.yml
+++ b/playbooks/roles/require_src_nginx/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Check for presence of SRC Nginx
+  tags: molecule-idempotence-notest
+  block:
+
+    - name: Check for presence of SRC Nginx SRAM authentication config
+      ansible.builtin.lineinfile:
+        line: "{{ item }}"
+        dest: /etc/nginx/app-location-conf.d/authentication.conf
+      check_mode: true
+      register: src_nginx_config
+      with_items:
+        - location @custom_401 {
+        - location = /oauth2_callback {
+        - location = /validate {
+
+    - name: Stop if SRC nginx config is not present
+      ansible.builtin.fail:
+        msg: The SRC-Nginx component must be run before this component
+      when: src_nginx_config.changed
+
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+    - name: Stop if nginx is not installed
+      ansible.builtin.fail:
+        msg: Nginx must be installed and active for this component to work.
+      when: services['nginx.service'].state != 'running'

--- a/playbooks/roles/uv/defaults/main.yml
+++ b/playbooks/roles/uv/defaults/main.yml
@@ -2,3 +2,5 @@
 uu_pipx_bin: /usr/local/uu-pip/bin
 uv_python_versions: []
 uv_venvs: []
+uv_become_user: root
+uv_become: false

--- a/playbooks/roles/uv/tasks/main.yml
+++ b/playbooks/roles/uv/tasks/main.yml
@@ -36,25 +36,25 @@
   become_user: "{{ uv_become_user }}"
   block:
 
-  - name: Install desired python version
-    ansible.builtin.command: uv python install -v {{ item }}
-    register: _install_desired_python
-    changed_when: '"Skipping" not in _install_desired_python.stderr'
-    with_items: "{{ uv_python_versions_install }}"
+    - name: Install desired python version
+      ansible.builtin.command: uv python install -v {{ item }}
+      register: _install_desired_python
+      changed_when: '"Skipping" not in _install_desired_python.stderr'
+      with_items: "{{ uv_python_versions_install }}"
 
-  - name: Set uv python install path facts step 1
-    ansible.builtin.command: uv python find {{ item }}
-    changed_when: false
-    register: _uv_python_finds
-    with_items: "{{ uv_python_versions_install }}"
+    - name: Set uv python install path facts step 1
+      ansible.builtin.command: uv python find {{ item }}
+      changed_when: false
+      register: _uv_python_finds
+      with_items: "{{ uv_python_versions_install }}"
 
-  - name: Set uv python install path facts step 2
-    ansible.builtin.set_fact:
-      uv_python_paths: "{{ (uv_python_paths | default({})) | combine({item.item: item.stdout}) }}"
-    with_items: "{{ _uv_python_finds.results }}"
+    - name: Set uv python install path facts step 2
+      ansible.builtin.set_fact:
+        uv_python_paths: "{{ (uv_python_paths | default({})) | combine({item.item: item.stdout}) }}"
+      with_items: "{{ _uv_python_finds.results }}"
 
-  - name: Create venvs
-    ansible.builtin.command:
-      cmd: uv venv --seed --python {{ item.python }} {{ item.path }}
-      creates: "{{ item.path }}"
-    with_items: "{{ uv_venvs }}"
+    - name: Create venvs
+      ansible.builtin.command:
+        cmd: uv venv --seed --python {{ item.python }} {{ item.path }}
+        creates: "{{ item.path }}"
+      with_items: "{{ uv_venvs }}"

--- a/playbooks/roles/uv/tasks/main.yml
+++ b/playbooks/roles/uv/tasks/main.yml
@@ -31,25 +31,30 @@
   ansible.builtin.set_fact:
     uv_python_versions_install: "{{ (uv_python_versions + (uv_venvs | map(attribute='python') | list)) | unique }}"
 
-- name: Install desired python version
-  ansible.builtin.command: uv python install -v {{ item }}
-  register: _install_desired_python
-  changed_when: '"Skipping" not in _install_desired_python.stderr'
-  with_items: "{{ uv_python_versions_install }}"
+- name: Perform uv commands
+  become: "{{ uv_become }}"
+  become_user: "{{ uv_become_user }}"
+  block:
 
-- name: Set uv python install path facts step 1
-  ansible.builtin.command: uv python find {{ item }}
-  changed_when: false
-  register: _uv_python_finds
-  with_items: "{{ uv_python_versions_install }}"
+  - name: Install desired python version
+    ansible.builtin.command: uv python install -v {{ item }}
+    register: _install_desired_python
+    changed_when: '"Skipping" not in _install_desired_python.stderr'
+    with_items: "{{ uv_python_versions_install }}"
 
-- name: Set uv python install path facts step 2
-  ansible.builtin.set_fact:
-    uv_python_paths: "{{ (uv_python_paths | default({})) | combine({item.item: item.stdout}) }}"
-  with_items: "{{ _uv_python_finds.results }}"
+  - name: Set uv python install path facts step 1
+    ansible.builtin.command: uv python find {{ item }}
+    changed_when: false
+    register: _uv_python_finds
+    with_items: "{{ uv_python_versions_install }}"
 
-- name: Create venvs
-  ansible.builtin.command:
-    cmd: uv venv --seed --python {{ item.python }} {{ item.path }}
-    creates: "{{ item.path }}"
-  with_items: "{{ uv_venvs }}"
+  - name: Set uv python install path facts step 2
+    ansible.builtin.set_fact:
+      uv_python_paths: "{{ (uv_python_paths | default({})) | combine({item.item: item.stdout}) }}"
+    with_items: "{{ _uv_python_finds.results }}"
+
+  - name: Create venvs
+    ansible.builtin.command:
+      cmd: uv venv --seed --python {{ item.python }} {{ item.path }}
+      creates: "{{ item.path }}"
+    with_items: "{{ uv_venvs }}"


### PR DESCRIPTION
This PR refactors roles and playbooks used for the purpose of serving flask apps with nginx reverse proxies:

* adds a separate, reusable role to check for the presence of the SRC-Nginx component
* updates the `nginx_uwgsi` role to support additional config parameters
* refactors the `flask_app` playbook into a `flask_app` role
* updates docs