### PR TITLE
Update run_and_pause.sh.j2

### DIFF
--- a/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
+++ b/playbooks/roles/uu_generic/templates/run_and_pause.sh.j2
@@ -14,7 +14,7 @@ check_params(){
   fi
 }
 
-check_params "$*";
+check_params "$@";
 
 if [ "$1" == "-s" ]; then
   SILENT="true"


### PR DESCRIPTION
When running `run_and_pause` without arguments it skips the check_params function for some reason I don't fully understand but apparently `$*` not < 1. `$@` passes existing arguments as an array and seems to behave as expected, but my bash knowledge is very limited so could you double check this @dometto ?