### PR TITLE
role asreview: support periodically adding local users

### DIFF
--- a/playbooks/roles/asreview_server/defaults/main.yml
+++ b/playbooks/roles/asreview_server/defaults/main.yml
@@ -10,3 +10,4 @@ asreview_server_http_password: ""
 asreview_server_http_username: ""
 asreview_server_use_storage: true
 asreview_server_group: www-data
+asreview_server_cron_users: true

--- a/playbooks/roles/asreview_server/defaults/main.yml
+++ b/playbooks/roles/asreview_server/defaults/main.yml
@@ -11,5 +11,3 @@ asreview_server_http_username: ""
 asreview_server_use_storage: true
 asreview_server_group: www-data
 asreview_server_cron_users: true
-asreview_server_use_storage: true
-asreview_server_group: www-data

--- a/playbooks/roles/asreview_server/defaults/main.yml
+++ b/playbooks/roles/asreview_server/defaults/main.yml
@@ -11,3 +11,5 @@ asreview_server_http_username: ""
 asreview_server_use_storage: true
 asreview_server_group: www-data
 asreview_server_cron_users: true
+asreview_server_use_storage: true
+asreview_server_group: www-data

--- a/playbooks/roles/asreview_server/files/requirements.txt
+++ b/playbooks/roles/asreview_server/files/requirements.txt
@@ -4,4 +4,4 @@
 # The PRs will trigger the tests, so we will automatically see if the new version is still compatible with this role.
 # The Dependabot config file is in .github/dependabot.yml
 
-asreview~=2.0
+asreview~=2.1

--- a/playbooks/roles/asreview_server/molecule/default/verify.yml
+++ b/playbooks/roles/asreview_server/molecule/default/verify.yml
@@ -41,8 +41,3 @@
         that:
           - '"- tester" in existing_users.stdout' # created by logging in above
           - '"- testuser" in existing_users.stdout' # created by the cronjob
-    
-    - name: Assert ASReview is on path for regular users
-      become: true
-      become_user: testuser
-      ansible.builtin.command: bash -l -c 'asreview --help'

--- a/playbooks/roles/asreview_server/molecule/default/verify.yml
+++ b/playbooks/roles/asreview_server/molecule/default/verify.yml
@@ -31,3 +31,13 @@
       become: true
       become_user: testuser
       ansible.builtin.command: bash -l -c 'asreview --help'
+
+    - name: Get existing users
+      ansible.builtin.command: /var/www/asreview/venv/bin/asreview auth-tool list-users --db sqlite:///var/www/asreview/asreview_data/asreview.production.sqlite
+      register: existing_users
+
+    - name: Assert existing users
+      ansible.builtin.assert:
+        that:
+          - '"- tester" in existing_users.stdout'
+          - '"- testuser" in existing_users.stdout' # added by the cronjob

--- a/playbooks/roles/asreview_server/molecule/default/verify.yml
+++ b/playbooks/roles/asreview_server/molecule/default/verify.yml
@@ -39,5 +39,10 @@
     - name: Assert existing users
       ansible.builtin.assert:
         that:
-          - '"- tester" in existing_users.stdout'
-          - '"- testuser" in existing_users.stdout' # added by the cronjob
+          - '"- tester" in existing_users.stdout' # created by logging in above
+          - '"- testuser" in existing_users.stdout' # created by the cronjob
+    
+    - name: Assert ASReview is on path for regular users
+      become: true
+      become_user: testuser
+      ansible.builtin.shell: asreview --help

--- a/playbooks/roles/asreview_server/molecule/default/verify.yml
+++ b/playbooks/roles/asreview_server/molecule/default/verify.yml
@@ -45,4 +45,4 @@
     - name: Assert ASReview is on path for regular users
       become: true
       become_user: testuser
-      ansible.builtin.shell: asreview --help
+      ansible.builtin.command: bash -l -c 'asreview --help'

--- a/playbooks/roles/asreview_server/tasks/cron.yml
+++ b/playbooks/roles/asreview_server/tasks/cron.yml
@@ -1,0 +1,34 @@
+---
+- name: Copy cron job
+  ansible.builtin.template:
+    src: templates/cron_asreview_user.sh.j2
+    dest: "{{ asreview_server_cron_script }}"
+    mode: "0700"
+    owner: root
+    group: root
+
+- name: Run user cron job for the first time
+  tags: molecule-idempotence-notest
+  ansible.builtin.shell: "{{ asreview_server_cron_script }}"
+
+- name: Create ASReview user cron job
+  ansible.builtin.cron:
+    name: "Add local users to ASReview"
+    minute: "*/10"
+    job: "{{ asreview_server_cron_script }} >> {{ asreview_server_cron_logfile }} 2>&1"
+
+- name: Enable logrotation for cron job
+  ansible.builtin.blockinfile:
+    path: /etc/logrotate.d/asreview_cron
+    block: >
+      {{ asreview_server_cron_logfile }} {
+        daily
+        rotate 5
+        size 50M
+        compress
+        delaycompress
+        missingok
+        copytruncate
+      }
+    create: true
+    mode: "0644"

--- a/playbooks/roles/asreview_server/tasks/cron.yml
+++ b/playbooks/roles/asreview_server/tasks/cron.yml
@@ -9,7 +9,7 @@
 
 - name: Run user cron job for the first time
   tags: molecule-idempotence-notest
-  ansible.builtin.shell: "{{ asreview_server_cron_script }}"
+  ansible.builtin.command: "{{ asreview_server_cron_script }}"
 
 - name: Create ASReview user cron job
   ansible.builtin.cron:

--- a/playbooks/roles/asreview_server/tasks/main.yml
+++ b/playbooks/roles/asreview_server/tasks/main.yml
@@ -107,6 +107,13 @@
     content: |
       export ASREVIEW_PATH="{{ asreview_server_env.ASREVIEW_PATH }}"
 
+- name: Add ASReview to default bash path
+  ansible.builtin.copy:
+    dest: /etc/profile.d/asreview-path.sh
+    mode: "0644"
+    content: |
+      export PATH="{{ flask_app_venv }}/bin${PATH:+:${PATH}}"
+
 - name: Start taskmanager
   block:
 

--- a/playbooks/roles/asreview_server/tasks/main.yml
+++ b/playbooks/roles/asreview_server/tasks/main.yml
@@ -91,12 +91,21 @@
     flask_app_uwsgi_env: "{{ asreview_server_env }}"
     flask_app_venv_user: "{{ asreview_server_user }}"
 
-- name: Add ASReview to default bash path
+- name: Install ASReview as CLI command for all users
+  ansible.builtin.include_role:
+    name: pipx_install_systemwide
+  vars:
+    pipx_install_systemwide_requirements: "{{ asreview_server_requirements_file }}"
+    pipx_install_systemwide_packages:
+      - asreview
+    pipx_install_systemwide_use_uv: true # uv has been installed by the flask_app role
+
+- name: Add path to ASReview data to default bash environment
   ansible.builtin.copy:
-    dest: /etc/profile.d/asreview-path.sh
+    dest: /etc/profile.d/asreview.sh
     mode: "0644"
     content: |
-      export PATH="{{ flask_app_venv }}/bin${PATH:+:${PATH}}"
+      export ASREVIEW_PATH="{{ asreview_server_env.ASREVIEW_PATH }}"
 
 - name: Start taskmanager
   block:

--- a/playbooks/roles/asreview_server/tasks/main.yml
+++ b/playbooks/roles/asreview_server/tasks/main.yml
@@ -91,22 +91,6 @@
     flask_app_uwsgi_env: "{{ asreview_server_env }}"
     flask_app_venv_user: "{{ asreview_server_user }}"
 
-- name: Install ASReview as CLI command for all users
-  ansible.builtin.include_role:
-    name: pipx_install_systemwide
-  vars:
-    pipx_install_systemwide_requirements: "{{ asreview_server_requirements_file }}"
-    pipx_install_systemwide_packages:
-      - asreview
-    pipx_install_systemwide_use_uv: true # uv has been installed by the flask_app role
-
-- name: Add path to ASReview data to default bash environment
-  ansible.builtin.copy:
-    dest: /etc/profile.d/asreview.sh
-    mode: "0644"
-    content: |
-      export ASREVIEW_PATH="{{ asreview_server_env.ASREVIEW_PATH }}"
-
 - name: Add ASReview to default bash path
   ansible.builtin.copy:
     dest: /etc/profile.d/asreview-path.sh

--- a/playbooks/roles/asreview_server/tasks/main.yml
+++ b/playbooks/roles/asreview_server/tasks/main.yml
@@ -16,6 +16,10 @@
       ASREVIEW_PATH: "{{ asreview_server_storage_path | default(asreview_server_default_data_dir, true) }}/asreview_data"
       ASREVIEW_LAB_CONFIG_PATH: "{{ asreview_server_config_file }}"
 
+- name: Set ASReview DB uri
+  ansible.builtin.set_fact:
+    asreview_server_db_uri: sqlite:///{{ asreview_server_env.ASREVIEW_PATH }}/asreview.production.sqlite
+
 - name: Ensure ASReview config dir present
   ansible.builtin.file:
     path: "{{ asreview_server_config_dir }}"
@@ -135,3 +139,7 @@
         name: asreview-taskmanager
         state: started
         enabled: true
+
+- name: Install cron job to add local users to ASReview
+  when: asreview_server_cron_users
+  ansible.builtin.include_tasks: cron.yml

--- a/playbooks/roles/asreview_server/templates/asreview_sram.toml.j2
+++ b/playbooks/roles/asreview_server/templates/asreview_sram.toml.j2
@@ -8,6 +8,7 @@ SESSION_COOKIE_SAMESITE = "Lax"
 SQLALCHEMY_TRACK_MODIFICATIONS = true
 ALLOW_ACCOUNT_CREATION = false
 EMAIL_VERIFICATION = false
+SQLALCHEMY_DATABASE_URI = "{{ asreview_server_db_uri }}"
 
 [REMOTE_USER]
 USER_IDENTIFIER_HEADER = '{{ asreview_server_remote_user_header }}'

--- a/playbooks/roles/asreview_server/templates/cron_asreview_user.sh.j2
+++ b/playbooks/roles/asreview_server/templates/cron_asreview_user.sh.j2
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+ASREVIEW_DB_URI="{{ asreview_server_db_uri }}"
+
+cd /etc/rsc/managedusers/
+
+echo "Attempting to add managed users to ASReview..."
+echo "Using ASReview database at: $ASREVIEW_DB_URI"
+echo
+
+for username in *; do
+
+if [[ "$username" == "*" ]]; then
+    echo "No managed users found."
+    exit 0
+fi
+
+echo "Adding local user $username to ASReview..."
+echo
+
+{{ asreview_server_config_dir }}/venv/bin/asreview auth-tool add-users --db "$ASREVIEW_DB_URI" -j \
+    "[{\"origin\": \"remote\", \"email\": \"$username@{{ asreview_server_default_email_domain }}\", \"name\": \"$username\", \"affiliation\": \"\", \"password\": \"\"}]"
+done

--- a/playbooks/roles/asreview_server/vars/main.yml
+++ b/playbooks/roles/asreview_server/vars/main.yml
@@ -5,3 +5,5 @@ asreview_server_requirements_file: "{{ asreview_server_config_dir }}/requirement
 asreview_server_user: www-data
 asreview_server_nginx_remote_user_var: "${{ (asreview_server_auth == 'basic') | ternary('remote_user', 'username') }}"
 asreview_server_default_data_dir: "{{ asreview_server_config_dir }}"
+asreview_server_cron_script: /etc/rsc/cron_asreview_user.sh
+asreview_server_cron_logfile: /var/log/asreview_cron.log


### PR DESCRIPTION
Currently SRAM users must first login to ASReview in order for them to become visible in the app. It would be nice if users were already visible, so they can be invited to projects before they are logged in.

This depends on https://github.com/asreview/asreview/pull/2192

- [x] Wait for next ASReview patch release
- [x] Update VRE docs
