### PR TITLE
playbook asreview_server: create default shared group

### DIFF
--- a/playbooks/asreview_server.yml
+++ b/playbooks/asreview_server.yml
@@ -3,4 +3,10 @@
   hosts: localhost
   gather_facts: true
   roles:
+    - role: default_group
+      vars:
+        default_group_group:
+          groupname: asreview_user
     - role: asreview_server
+      vars:
+        asreview_server_group: asreview_user


### PR DESCRIPTION
This allows all regular users on the workspace access to ASReview's data directory.