### PR TITLE
Fix Ubuntu22 icommands

### DIFF
--- a/playbooks/icommands.yml
+++ b/playbooks/icommands.yml
@@ -7,6 +7,5 @@
   #  vars:
   #    - irods_repo_apt_release: "bionic"
   roles:
-    - irods_repo
-    - irods_icommands
-    - irods_skel
+    - role: irods_icommands
+    - role: irods_skel

--- a/playbooks/icommands.yml
+++ b/playbooks/icommands.yml
@@ -2,10 +2,12 @@
 - name: Install iRODS iCommands toolset in researchcloud workspace
   hosts: localhost
   gather_facts: true
-
-  #  NB: irods supports Ubuntu 18, use below to fix repo to such level:
-  #  vars:
-  #    - irods_repo_apt_release: "bionic"
+  tasks:
+    - name: Override default icommands version for ubuntu > 20
+      # Yoda requires a lower version of the icommands than the latest version on Ubuntu >= 22
+      when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version | int > 20
+      ansible.builtin.set_fact:
+        irods_repo_apt_release: focal
   roles:
     - role: irods_icommands
     - role: irods_skel

--- a/playbooks/roles/fact_regular_users/meta/main.yml
+++ b/playbooks/roles/fact_regular_users/meta/main.yml
@@ -1,5 +1,4 @@
 ---
-
 galaxy_info:
   author: Ton Smeele
   description: obtain a data structure with a list of regular Linux users

--- a/playbooks/roles/irods_icommands/meta/main.yml
+++ b/playbooks/roles/irods_icommands/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  author: Ton Smeele
+  description: Install the iRODS iCommands
+  license: GPLv3
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+        - bookworm
+    - name: EL
+      versions:
+        - all
+dependencies:
+  - irods_repo

--- a/playbooks/roles/irods_icommands/molecule/default/converge.yml
+++ b/playbooks/roles/irods_icommands/molecule/default/converge.yml
@@ -3,7 +3,6 @@
   hosts: all
   gather_facts: true
   roles:
-    - role: irods_repo
-    - role: irods_icommands
+    - role: irods_icommands # irods_repo is auto-required by this role
     - role: irods_iselect
     - role: irods_skel


### PR DESCRIPTION
Yoda is not compatible with the latest iCommands at the moment. On Ubuntu < 22, the highest available version is compatible with Yoda. Ensure that on Ubuntu > 20, a lower version of iCommands is installed. See issue #276