### PR TITLE
role asreview_server: fix cron setup

### DIFF
--- a/playbooks/roles/asreview_server/defaults/main.yml
+++ b/playbooks/roles/asreview_server/defaults/main.yml
@@ -10,4 +10,4 @@ asreview_server_http_password: ""
 asreview_server_http_username: ""
 asreview_server_use_storage: true
 asreview_server_group: www-data
-asreview_server_cron_users: false
+asreview_server_cron_users: true


### PR DESCRIPTION
There are appears to be a bug in the cron user setup: when users are already created in cron, login via SRAM fails, because this tries to re-create the same user. This PR attempts to fix this issue.