### PR TITLE
role jupyterhub: move extensions to other roles.

### DIFF
--- a/playbooks/jupyterhub.yml
+++ b/playbooks/jupyterhub.yml
@@ -2,11 +2,14 @@
 - name: Install JupyterHub
   hosts: localhost
   gather_facts: true
+  vars:
+    _jupyterhub_default_pkgs: # Extensions that should be installed on the hub (pypi packages)
+      - jupyterlab-git
   roles:
     - role: jupyterhub
       vars:
         jupyterhub_uri: "{{ jupyter_uri | default('/', true) }}"
-        jupyterhub_extra_pkgs: "{{ jupyter_extra_pkgs | default('', true) | split(',') }}"
+        jupyterhub_extra_pkgs: "{{ _jupyterhub_default_pkgs + (jupyter_extra_pkgs | default('', true) | split(',')) }}"
         jupyterhub_config_extra: "{{ jupyter_config_extra | default('', true) }}"
         jupyterhub_auth: "{{ jupyter_auth | default(omit, true) }}"
         jupyterhub_activate_remote_user_auth: "{{ jupyter_activate_remote_user_auth | default(omit, true) }}"

--- a/playbooks/roles/jupyterhub/vars/main.yml
+++ b/playbooks/roles/jupyterhub/vars/main.yml
@@ -7,8 +7,6 @@ jupyterhub_basic_pkgs:
   - jupyterhub
   - jhub-remote-user-authenticator
   - sudospawner
-  - jupyter-server-proxy
-  - jupyterlab-git
 jupyterhub_default_proxy_config:
   name: jupyterhub
   location: "{{ jupyterhub_uri }}"

--- a/playbooks/roles/jupyterhub_app/tasks/main.yml
+++ b/playbooks/roles/jupyterhub_app/tasks/main.yml
@@ -9,6 +9,13 @@
   ansible.builtin.fail:
     msg: "Could not find venv in {{ _jupyterhub_app_venv }}. Exiting!"
 
+- name: Install jupyter-server-proxy
+  ansible.builtin.pip:
+    executable: "{{ jupyterhub_app_pip_executable }}"
+    name: jupyter-server-proxy
+  environment:
+    VIRTUAL_ENV: "{{ _jupyterhub_app_venv }}"
+
 - name: Install extension into venv
   when: jupyterhub_app_pip | length > 0
   ansible.builtin.pip:


### PR DESCRIPTION
The jupyterhub role by default installed packages that are not needed on a barebones installation (e.g. when using the jupyterhub_standalone_proxy role). This PR moves the installation of those dependencies to jupyterhub_app and the jupyterhub component, where they are actually needed.
