### PR TITLE
role jupyterhub: add jupyterlab to basic packages

### DIFF
--- a/playbooks/roles/jupyterhub/vars/main.yml
+++ b/playbooks/roles/jupyterhub/vars/main.yml
@@ -5,6 +5,7 @@ jupyterhub_venv: "/usr/local/jupyterhub"
 jupyterhub_sudospawner_path: "{{ jupyterhub_venv }}/bin/sudospawner"
 jupyterhub_basic_pkgs:
   - jupyterhub
+  - jupyterlab
   - jhub-remote-user-authenticator
   - sudospawner
 jupyterhub_default_proxy_config:


### PR DESCRIPTION
Looks like jupyterlab was previously installed as a dependency of another package, but it now no longer is. This obviously breaks jupyterlab.
