### PR TITLE
role uu_generic: refactor snap installations

### DIFF
--- a/playbooks/roles/uu_generic/molecule/default/molecule.yml
+++ b/playbooks/roles/uu_generic/molecule/default/molecule.yml
@@ -10,8 +10,8 @@ provisioner:
     ANSIBLE_ROLES_PATH: ../../../
 role_name_check: 1
 platforms:
-  - name: workspace-src-ubuntu_focal-desktop
-    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_focal-desktop
+  - name: workspace-src-ubuntu_jammy-desktop
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy-desktop
     pre_build_image: true
     command: /sbin/init
     privileged: true # needed for snapd

--- a/playbooks/roles/uu_generic/tasks/apps.yml
+++ b/playbooks/roles/uu_generic/tasks/apps.yml
@@ -1,13 +1,10 @@
 ---
-- name: Install desktop apps
+- name: Install snap desktop apps
   when: fact_desktop_workspace
-  block:
-    - name: Install snap apps
-      community.general.snap:
-        classic: true
-        name:
-          - codium
-          - pycharm-community
+  community.general.snap:
+    classic: true
+    name:
+      - codium
 
 - name: Install run_and_pause script
   ansible.builtin.template:

--- a/playbooks/roles/uu_generic/tasks/apps.yml
+++ b/playbooks/roles/uu_generic/tasks/apps.yml
@@ -1,10 +1,12 @@
 ---
-- name: Install snap desktop apps
+- name: Install desktop apps
   when: fact_desktop_workspace
-  community.general.snap:
-    classic: true
-    name:
-      - codium
+  block:
+    - name: Install codium
+      community.general.snap:
+        classic: true
+        state: present
+        name: codium
 
 - name: Install run_and_pause script
   ansible.builtin.template:

--- a/playbooks/roles/uu_generic/tasks/apps.yml
+++ b/playbooks/roles/uu_generic/tasks/apps.yml
@@ -2,14 +2,12 @@
 - name: Install desktop apps
   when: fact_desktop_workspace
   block:
-    - name: Refresh snaps
-      ansible.builtin.command: snap refresh
-      tags: molecule-idempotence-notest
-
-    - name: Install VSCodium
-      ansible.builtin.command: snap install codium --classic
-      register: uu_generic_install_codium
-      changed_when: '"already installed" not in uu_generic_install_codium.stderr'
+    - name: Install snap apps
+      community.general.snap:
+        classic: true
+        name:
+          - codium
+          - pycharm-community
 
 - name: Install run_and_pause script
   ansible.builtin.template:

--- a/playbooks/roles/uu_generic/tasks/apps.yml
+++ b/playbooks/roles/uu_generic/tasks/apps.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install desktop apps
-  when: fact_desktop_workspace
+  when:
+    - fact_desktop_workspace
+    - ansible_virtualization_type is not defined or ansible_virtualization_type not in ['podman', 'docker', 'container']
   block:
     - name: Install codium
       community.general.snap:

--- a/playbooks/roles/uu_generic/tasks/apps.yml
+++ b/playbooks/roles/uu_generic/tasks/apps.yml
@@ -1,8 +1,7 @@
 ---
-- name: Install desktop apps
-  when:
-    - fact_desktop_workspace
-    - ansible_virtualization_type is not defined or ansible_virtualization_type not in ['podman', 'docker', 'container']
+- name: Install desktop snaps
+  when: fact_desktop_workspace
+  tags: molecule-notest
   block:
     - name: Install codium
       community.general.snap:


### PR DESCRIPTION
This PR adds pycharm to all desktop workspaces. @jelletreep I am wondering if this is desirable; yesterday I had a meeting with another user who basically does everything with pycharm. So I thought I'd open this PR for discussion; do we want to add it to *all* workspaces (including e.g. R-Workbench)? There isn't really any downside, except the time it takes to `snap install` it . But for support I'm not sure: is it better if users can use an IDE they know, or for us to have to support only a limited number of IDEs (i.e. VSCode)?