### PR TITLE
Update src_ansible_venv fact logic

### DIFF
--- a/playbooks/roles/fact_workspace_info/tasks/main.yml
+++ b/playbooks/roles/fact_workspace_info/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Set src_ansible_venv fact
   ansible.builtin.set_fact:
-    fact_src_ansible_venv: "{{ src_ansible_venv.stat.exists | ternary(src_ansible_venv.stat.path, '') }}"
+    fact_src_ansible_venv: "{{ (src_ansible_venv.stat.exists or 'molecule-roletest' ansible_skip_tags) | ternary(src_ansible_venv.stat.path, false) }}"
 
 - name: Get workspace.json file
   ansible.builtin.command: cat /etc/rsc/workspace.json


### PR DESCRIPTION
The role (as opposed to playbook) tests were not testing the logic for installing dependencies into the SRC Ansible venv.

Todo:

- [ ] Add molecule-noroletest to skiptags in molecule role tests
- [ ] Refactor checks (now testing for length, must test for boolean)
