### PR TITLE
Turbovnc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,7 @@ The status of a role is either Experimental or Supported. Supported roles are su
 - [system_python](roles/system_python.md) install latests version of python available through the system package manager
 - [tidyverse_dependencies](roles/tidyverse_dependencies.md)
 - [tigervnc](roles/tigervnc.md) installs TigerVNC server
+- [turbo](roles/turbo.md) installs TurboVNC server
 - [transferuser](roles/transferuser.md)
 - [uu_generic](roles/uu_generic.md) generic uu flavouring for workspaces
 - [uv](roles/uv.md) lightning fast python version and dependency manager

--- a/docs/playbooks/jupyterhub.md
+++ b/docs/playbooks/jupyterhub.md
@@ -12,7 +12,7 @@ Although SURF also has a *Jupyter Notebooks* component that installs JupyterHub,
 - Configure the Hub to be able to add arbitrary extensions to JupyterLab, or arbritary standalone apps to the Hub, using other components.
     - See the [jupyterhub_app role](../roles/jupyterhub_app.md) for this.
 
-On Desktop workspaces, this playbook will also install [TigerVNC](../../roles/tigervnc/) and install the JupyterHub extension [jupyter-remote-desktop-proxy)](github.com/jupyterhub/jupyter-remote-desktop-proxy) to allow the user to start a Desktop session from JupyterHub.
+On Desktop workspaces, this playbook will also install [TigerVNC](../roles/turbovnc.md) or [TurboVNC](..//roles/turbovnc) and install the JupyterHub extension [jupyter-remote-desktop-proxy)](github.com/jupyterhub/jupyter-remote-desktop-proxy) to allow the user to start a Desktop session from JupyterHub. TurboVNC is used on workspaces with a GPU.
 
 ## Requires
 

--- a/docs/roles/fact_workspace_info.md
+++ b/docs/roles/fact_workspace_info.md
@@ -8,6 +8,10 @@ Makes information about the workspace and CO available as Ansible facts. Provide
 - `fact_desktop_workspace` -- Boolean. True if the workspace has a desktop environment.
 - `fact_workspace_storage` -- List. List of Strings of paths to ResearchCloud storage volumes mounted on the workspace.
 - `fact_src_ansible_venv` -- string path to the python environment currently being used by Ansible. Can be used to install additional `pip` dependencies for Ansible modules into the correct environment. Empty string if Ansible is not using a virtual environment (but instead the global system python environment).
+- `fact_workspace_gpus`: List. Contains dicts describing available GPUs. Obtained using the `lshw -class display` command, filtering on descriptions containing '3d' (this works at least for NVIDIA GPUs, untested with others).
+- `fact_workspace_has_gpu`: Boolean. Whether the workspace has any GPUs (convenience fact determined on the basis of `fact_workspace_gpus`).
+- `fact_cuda_version`: String. CUDA release version (e.g. `13.2`), or empty.
+- `fact_all_graphics_cards`: String. Fact listing all graphics cards (whether GPU or not). Mostly for internal use in the role, to find GPUs.
 
 ## Requires
 Linux flavor operating system.

--- a/docs/roles/jupyterhub_app.md
+++ b/docs/roles/jupyterhub_app.md
@@ -62,7 +62,7 @@ This generated config will be placed into the directory `standalone` inside the 
 
 - `jupyterhub_app_venv`: String. Path to the JupyterHub instance's `venv`. Default: `/usr/local/jupyterhub`. You can set this to the value `system` to not use a virtual environment.
 - `jupyterhub_app_config_dir`: String. Path to the JupyterHub's instance config dir. Default: `/usr/local/etc/jupyter`.
-- `jupyterhub_app_pip_executable`: String. Which command to use to install packages into the venv (can be set to `uv` when it is available). Default: `pip`.
+- `jupyterhub_app_pip_executable`: String. Which command to use to install packages into the venv (can be set to `uv` when it is available). Default: [`uv_pip`](./uv.md).
 - `jupyterhub_app_pip`: String. Optional. Which package to install into the hub's venv (if set). Default: `""`. If this is set, no traitles config file will be placed.
 
 ### Variables concerning the application

--- a/docs/roles/tigervnc.md
+++ b/docs/roles/tigervnc.md
@@ -14,11 +14,12 @@ Installs the required packages for TigerVNC.
 
 TigerVNC is not automatically run: different roles or playbooks can determine when and how VNC sessions should be created. See e.g. the [JupyterHub playbook](../../playbooks/jupyterhub.yml).
 
-The `tigervnc_xstartup_path` fact is set to the value of the default `xstartup` script installed by TigerVNC. This can be used to start VNC sessions.
+The `vnc_xstartup_path` fact is set to the value of the default `xstartup` script installed by TigerVNC. This can be used to start VNC sessions.
 
 ## See also
 
 - playbook [jupyterhub](../../playbooks/jupyterhub.yml)
+- role [turbovnc](./turbovnc.md)
 
 ## History
 2022-24 Written by Dawa Ometto (Utrecht University)

--- a/docs/roles/turbovnc.md
+++ b/docs/roles/turbovnc.md
@@ -1,0 +1,27 @@
+# Role turbovnc
+[back to index](../index.md#Roles)
+
+## Summary
+Installs [TurboVNC](https://turbovnc.org/) server as well as the [VirtualGL](https://www.virtualgl.org/) library for hardware-accellerated rendering. TurboVNC is optimized for fast GPU accellerated rendering.
+
+## Requirements
+
+- Debian/Ubuntu workspace with Desktop
+
+## Description
+
+Installs the required packages for TurboVNC from the TurboVNC apt PPA.
+
+TurboVNC is not automatically run: different roles or playbooks can determine when and how VNC sessions should be created. See e.g. the [JupyterHub playbook](../../playbooks/jupyterhub.yml).
+
+The `vnc_xstartup_path` fact is set to the value of the default `xstartup` script installed by TurboVNC. This can be used to start VNC sessions.
+
+## See also
+
+- playbook [jupyterhub](../../playbooks/jupyterhub.yml)
+- role [tigervnc](./tigervnc.md)
+
+## History
+2022-24 Written by Dawa Ometto (Utrecht University)
+
+[back to index](../index.md#Roles)

--- a/molecule/playbook-jupyterhub/molecule.yml
+++ b/molecule/playbook-jupyterhub/molecule.yml
@@ -1,7 +1,7 @@
 ---
 platforms:
-  - name: workspace-src-ubuntu_jammy-nginx
-    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy-nginx
+  - name: workspace-src-ubuntu-nginx
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_noble-nginx
     command: /sbin/init
     pre_build_image: true
     published_ports:

--- a/playbooks/jupyterhub.yml
+++ b/playbooks/jupyterhub.yml
@@ -20,7 +20,7 @@
           {% if fact_desktop_workspace %}
           from pwd import getpwnam
           c.Spawner.environment.update({
-            'JUPYTER_REMOTE_DESKTOP_PROXY_XSTARTUP': '{{ tigervnc_xstartup_path }}',
+            'JUPYTER_REMOTE_DESKTOP_PROXY_XSTARTUP': '{{ vnc_xstartup_path }}',
             # We need to specify the following variable because the standard tigervnc xstartup script does not set it correctly
             # spawner.user is the user the vnc server will run as
             'XDG_RUNTIME_DIR': lambda spawner : f"/run/user/{getpwnam(spawner.user.name).pw_uid}",

--- a/playbooks/jupyterhub.yml
+++ b/playbooks/jupyterhub.yml
@@ -8,7 +8,9 @@
   roles:
     - role: fact_workspace_info
     - role: tigervnc
-      when: fact_desktop_workspace
+      when: fact_desktop_workspace and not fact_workspace_has_gpu
+    - role: turbovnc
+      when: fact_desktop_workspace and fact_workspace_has_gpu
     - role: jupyterhub
       vars:
         jupyterhub_uri: "{{ jupyter_uri | default('/', true) }}"
@@ -21,7 +23,8 @@
             'JUPYTER_REMOTE_DESKTOP_PROXY_XSTARTUP': '{{ tigervnc_xstartup_path }}',
             # We need to specify the following variable because the standard tigervnc xstartup script does not set it correctly
             # spawner.user is the user the vnc server will run as
-            'XDG_RUNTIME_DIR': lambda spawner : f"/run/user/{getpwnam(spawner.user.name).pw_uid}"
+            'XDG_RUNTIME_DIR': lambda spawner : f"/run/user/{getpwnam(spawner.user.name).pw_uid}",
+            'TVNC_WM': 'xfce' # force windowmanager to xfce for TurboVNC
           })
           {% endif %}
         jupyterhub_auth: "{{ jupyter_auth | default('sram', true) }}"

--- a/playbooks/roles/fact_regular_users/molecule/default/molecule.yml
+++ b/playbooks/roles/fact_regular_users/molecule/default/molecule.yml
@@ -30,8 +30,8 @@ scenario:
     - cleanup
     - destroy
 platforms:
-  - name: workspace-src-ubuntu_focal-desktop
-    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_focal-desktop
+  - name: workspace-src-ubuntu-desktop
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_noble-desktop
     <<: *image_settings
   - name: workspace-src-ubuntu_jammy
     image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy

--- a/playbooks/roles/fact_regular_users/molecule/default/verify.yml
+++ b/playbooks/roles/fact_regular_users/molecule/default/verify.yml
@@ -20,7 +20,7 @@
       ansible.builtin.assert:
         that:
           - item.user == 'testuser'
-          - item.userid == 1000
+          - item.userid >= 1000 and item.userid <= 1010
           - item.groupid >= 1000 and item.groupid <= 1010
           - item.home == '/home/testuser'
           - item.shell == '/usr/bin/bash'

--- a/playbooks/roles/fact_workspace_info/molecule/default/molecule.yml
+++ b/playbooks/roles/fact_workspace_info/molecule/default/molecule.yml
@@ -29,8 +29,8 @@ scenario:
     - cleanup
     - destroy
 platforms:
-  - name: workspace-src-ubuntu_focal-desktop
-    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_focal-desktop
+  - name: workspace-src-ubuntu-desktop
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_noble-desktop
     <<: *image_settings
   - name: workspace-src-ubuntu_jammy
     image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy

--- a/playbooks/roles/fact_workspace_info/molecule/default/verify.yml
+++ b/playbooks/roles/fact_workspace_info/molecule/default/verify.yml
@@ -24,3 +24,6 @@
         that:
           - fact_workspace_info['workspace_id'] == 'mocked'
           - fact_desktop_workspace == ('desktop' in inventory_hostname)
+          - fact_workspace_has_gpu == false
+          - fact_workspace_gpus == []
+          - fact_cuda_version == ""

--- a/playbooks/roles/fact_workspace_info/tasks/main.yml
+++ b/playbooks/roles/fact_workspace_info/tasks/main.yml
@@ -33,15 +33,56 @@
   ansible.builtin.set_fact:
     fact_workspace_storage: "{{ ansible_mounts | selectattr('mount', 'search', '^/data/') | list }}"
 
-- name: Get all packages as facts
-  ansible.builtin.package_facts:
-    manager: auto
-  no_log: true
+- name: Is the workspace a desktop workspace?
+  block:
+    - name: Get all packages as facts
+      ansible.builtin.package_facts:
+        manager: auto
+      no_log: true
 
-- name: Get the desktop package to check for
-  ansible.builtin.set_fact:
-    _workspace_info_desktop_package: "{{ _fact_workspace_info_desktop_package_for_os[ansible_os_family] | default(omit) }}"
+    - name: Get the desktop package to check for
+      ansible.builtin.set_fact:
+        _workspace_info_desktop_package: "{{ _fact_workspace_info_desktop_package_for_os[ansible_os_family] | default(omit) }}"
 
-- name: Set fact_desktop_workspace
-  ansible.builtin.set_fact:
-    fact_desktop_workspace: "{{ _workspace_info_desktop_package is defined and _workspace_info_desktop_package in ansible_facts.packages }}"
+    - name: Set fact_desktop_workspace
+      ansible.builtin.set_fact:
+        fact_desktop_workspace: "{{ _workspace_info_desktop_package is defined and _workspace_info_desktop_package in ansible_facts.packages }}"
+
+- name: Does the workspace have a GPU?
+  block:
+    - name: Get graphics cards info
+      ansible.builtin.command: lshw -class display -json
+      register: graphics_info
+      changed_when: false
+
+    - name: Set graphics fact
+      ansible.builtin.set_fact:
+        fact_all_graphics_cards: "{{ graphics_info.stdout | from_json | default([], true) }}"
+
+    - name: Set GPU fact
+      ansible.builtin.set_fact: # noqa jinja[spacing]
+        fact_workspace_gpus: "{{ (
+          ( fact_all_graphics_cards
+            | selectattr('description', 'defined')
+            | selectattr('description', 'search', '\\b(3D|gpu)\\b', ignorecase=True)
+            | list)
+          +
+          ( fact_all_graphics_cards
+            | selectattr('configuration.driver', 'defined')
+            | selectattr('configuration.driver', 'equalto', 'nvidia')
+            | list)
+        ) }}"
+
+    - name: Set has GPU fact
+      ansible.builtin.set_fact:
+        fact_workspace_has_gpu: "{{ fact_workspace_gpus | length > 0 }}"
+
+    - name: Get CUDA version
+      ansible.builtin.command: nvcc --version
+      register: cuda_version
+      failed_when: false
+      changed_when: false
+
+    - name: Set fact cuda version
+      ansible.builtin.set_fact:
+        fact_cuda_version: "{{ cuda_version.stdout | regex_search('release (.*),', '\\1', multiline=True) | default('', true) }}"

--- a/playbooks/roles/tigervnc/molecule/default/molecule.yml
+++ b/playbooks/roles/tigervnc/molecule/default/molecule.yml
@@ -16,6 +16,6 @@ provisioner:
     ANSIBLE_ROLES_PATH: ../../../
 role_name_check: 1
 platforms:
-  - name: workspace-src-ubuntu_jammy-desktop
-    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_jammy-desktop
+  - name: workspace-src-ubuntu-desktop
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_noble-desktop
     <<: *image_settings

--- a/playbooks/roles/tigervnc/tasks/main.yml
+++ b/playbooks/roles/tigervnc/tasks/main.yml
@@ -10,4 +10,4 @@
 
 - name: Set path to default start script
   ansible.builtin.set_fact:
-    tigervnc_xstartup_path: "{{ tigervnc_xstartup | default(tigervnc_default_xstartup_path['{{ ansible_os_family }}'], true) | default(tigervnc_default_xstartup_path['default']) }}"
+    vnc_xstartup_path: "{{ tigervnc_xstartup | default(tigervnc_default_xstartup_path['{{ ansible_os_family }}'], true) | default(tigervnc_default_xstartup_path['default']) }}"

--- a/playbooks/roles/turbovnc/defaults/main.yml
+++ b/playbooks/roles/turbovnc/defaults/main.yml
@@ -1,0 +1,1 @@
+turbovnc_xstartup: ""

--- a/playbooks/roles/turbovnc/meta/main.yml
+++ b/playbooks/roles/turbovnc/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Dawa Ometto
+  description: Install virtualgl and turbovnc server
+  license: GPLv3
+  min_ansible_version: "2.9"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+        - bookworm
+dependencies:
+  - fact_workspace_info

--- a/playbooks/roles/turbovnc/molecule/default/converge.yml
+++ b/playbooks/roles/turbovnc/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: true
+  roles:
+    - role: turbovnc

--- a/playbooks/roles/turbovnc/molecule/default/molecule.yml
+++ b/playbooks/roles/turbovnc/molecule/default/molecule.yml
@@ -1,0 +1,21 @@
+---
+driver:
+  name: ${DRIVER-podman}
+  image_settings: &image_settings
+    pre_build_image: true
+    registry:
+      url: $DOCKER_REGISTRY
+      credentials:
+        username: $DOCKER_USER
+        password: $DOCKER_PW
+provisioner:
+  name: ansible
+  playbooks:
+    converge: ./converge.yml
+  env:
+    ANSIBLE_ROLES_PATH: ../../../
+role_name_check: 1
+platforms:
+  - name: workspace-src-ubuntu-desktop
+    image: ghcr.io/utrechtuniversity/src-test-workspace:ubuntu_noble-desktop
+    <<: *image_settings

--- a/playbooks/roles/turbovnc/tasks/main.yml
+++ b/playbooks/roles/turbovnc/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: Install dependencies (Debian)
+  when: ansible_os_family == "Debian"
+  block:
+    # Install VirtualGL for hardware-accelerated VNC: https://virtualgl.org
+    # Install TurboVNC: https://turbovnc.org/
+    - name: Get virtualgl apt key
+      ansible.builtin.get_url:
+        url: https://packagecloud.io/dcommander/virtualgl/gpgkey
+        dest: /usr/share/keyrings/virtualgl.key
+        mode: "0644"
+
+    - name: Add virtualgl apt repo
+      ansible.builtin.apt_repository:
+        repo: deb [signed-by=/usr/share/keyrings/virtualgl.key] https://packagecloud.io/dcommander/virtualgl/any/ any main
+        state: present
+        filename: renci-irods
+        update_cache: false
+
+    - name: Get turbovnc apt key
+      ansible.builtin.get_url:
+        url: https://packagecloud.io/dcommander/turbovnc/gpgkey
+        dest: /usr/share/keyrings/turbovnc.key
+        mode: "0644"
+
+    - name: Add virtualgl apt repo
+      ansible.builtin.apt_repository:
+        repo: deb [signed-by=/usr/share/keyrings/turbovnc.key] https://packagecloud.io/dcommander/turbovnc/any/ any main
+        state: present
+        filename: turbovnc
+        update_cache: false
+
+    - name: Install packages
+      ansible.builtin.apt:
+        update_cache: true
+        name:
+          - dbus-x11
+          - virtualgl
+          - turbovnc
+        state: present
+
+- name: Ensure binaries are on PATH
+  block:
+    - name: Find TurboVNC binaries
+      ansible.builtin.find:
+        paths: /opt/TurboVNC/bin/
+        file_type: file
+        recurse: false
+      register: turbovnc_binaries
+
+    - name: Create symlinks
+      ansible.builtin.file:
+        src: "{{ item.path }}"
+        path: "/usr/bin/{{ item.path | basename }}"
+        state: link
+        owner: root
+        group: root
+      with_items: "{{ turbovnc_binaries.files }}"
+
+- name: Set path to default start script
+  ansible.builtin.set_fact:
+    vnc_xstartup_path: "{{ turbovnc_xstartup | default(turbovnc_default_xstartup_path['{{ ansible_os_family }}'], true) | default(turbovnc_default_xstartup_path['default']) }}"
+
+- name: Ensure required nvida kernel modules are active
+  when: (fact_cuda_version | length) > 0
+  community.general.modprobe:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - nvidia_modeset
+    - nvidia_uvm
+    - nvidia_drm

--- a/playbooks/roles/turbovnc/vars/main.yml
+++ b/playbooks/roles/turbovnc/vars/main.yml
@@ -1,0 +1,3 @@
+turbovnc_default_xstartup_path:
+  Debian: /opt/TurboVNC/bin/xstartup.turbovnc
+  default: /opt/TurboVNC/bin/xstartup.turbovnc


### PR DESCRIPTION
Resolves #135

TurboVNC has better support for hardware accelerated rendering than TigerVNC, making it a better performing choice for working with 3D images. `jupyter-remote-desktop-proxy` can use both VNC servers. This PR:

- Adds role turbovnc.
- Adds a fact that tracks whether the workspace has a GPU
- In playbook JupyterHub with desktop: check if workspace has GPU, if so, use TurboVNC.