### PR TITLE
role default_group: use cron instead of adduser conf

### DIFF
--- a/playbooks/roles/default_group/defaults/main.yml
+++ b/playbooks/roles/default_group/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+default_group_use_cron: true

--- a/playbooks/roles/default_group/files/add_regular_users_to_group.sh
+++ b/playbooks/roles/default_group/files/add_regular_users_to_group.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# Require group name as $1
+if [ $# -lt 1 ] || [ -z "$1" ]; then
+    echo "Usage: $0 <groupname>" >&2
+    exit 1
+fi
+
+TARGET_GROUP="$1"
+
+# Ensure group exists
+if ! getent group "$TARGET_GROUP" >/dev/null; then
+    echo "Group $TARGET_GROUP does not exist" >&2
+    exit 1
+fi
+
+for homedir in /home/*; do
+    # Skip non-directories
+    [ -d "$homedir" ] || continue
+
+    user="$(basename "$homedir")"
+
+    # Skip if user does not exist
+    if ! id "$user" >/dev/null 2>&1; then
+        continue
+    fi
+
+    # Add user to group if not already a member
+    if ! id -nG "$user" | grep -qw "$TARGET_GROUP"; then
+        usermod -aG "$TARGET_GROUP" "$user"
+        echo "Added $user to $TARGET_GROUP"
+    fi
+done

--- a/playbooks/roles/default_group/molecule/default/converge.yml
+++ b/playbooks/roles/default_group/molecule/default/converge.yml
@@ -16,3 +16,7 @@
       vars:
         default_group_group:
           groupname: testgroup2
+    - name: Create testuser2
+      ansible.builtin.user: # this will user useradd, not adduser
+        name: testuser2
+        create_home: true

--- a/playbooks/roles/default_group/molecule/default/verify.yml
+++ b/playbooks/roles/default_group/molecule/default/verify.yml
@@ -3,10 +3,10 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Create test user
-      ansible.builtin.command: /usr/sbin/adduser --disabled-password --gecos "" testuser2
-      register: adduser
-      changed_when: adduser.rc == 0
+    - name: Run cronjob for testgroup1
+      ansible.builtin.command: "/etc/rsc/add_regular_users_to_group.sh testgroup1"
+    - name: Run cronjob for testgroup2
+      ansible.builtin.command: "/etc/rsc/add_regular_users_to_group.sh testgroup2"
     - name: List testuser groups
       ansible.builtin.command: groups testuser
       changed_when: false
@@ -41,4 +41,4 @@
         that:
           - 'list_groups_newuser.stdout == "testuser2 : testuser2 testgroup1 testgroup2"'
           - 'list_groups_olduser.stdout == "testuser : testuser testgroup1 testgroup2"'
-          - list_gids_newuser.stdout == "1004 5000 5001" # 1004 is the gid for testuser2 as testuser1 has 1001, and sudoers and fuse have 1002 and 1003
+          - 'list_gids_newuser.stdout == "5002 5000 5001"'

--- a/playbooks/roles/default_group/tasks/main.yml
+++ b/playbooks/roles/default_group/tasks/main.yml
@@ -12,11 +12,34 @@
     line: "*;*;*;Al0000-2400;{{ default_group_group.groupname }}"
 
 - name: Add existing regular users to new group
+  when: not default_group_use_cron
   ansible.builtin.user:
     name: "{{ item.user }}"
     groups: "{{ default_group_group.groupname }}"
     append: true
   with_items: "{{ fact_regular_users }}"
+
+- name: Cronjob
+  when: default_group_use_cron
+  block:
+    - name: Place script
+      ansible.builtin.copy:
+        src: add_regular_users_to_group.sh
+        dest: /etc/rsc/add_regular_users_to_group.sh
+        mode: "0700"
+        owner: root
+        group: root
+
+    - name: Add existing regular users to new group
+      tags: molecule-idempotence-notest
+      ansible.builtin.command: "/etc/rsc/add_regular_users_to_group.sh {{ default_group_group.groupname | quote }}"
+
+    - name: Add cronjob for adding home users to group
+      ansible.builtin.cron:
+        name: "Add regular users to group {{ default_group_group.groupname }}"
+        user: root
+        job: "/etc/rsc/add_regular_users_to_group.sh {{ default_group_group.groupname | quote }} >> /var/log/src.txt 2>&1"
+        minute: "*/5"
 
 # This assumes users are added with /usr/sbin/useradd
 - name: Ubuntu


### PR DESCRIPTION
SURF has switched to using `useradd` instead of `adduser` for creating new users from SRAM on workspaces. This means our `/etc/adduser.conf` config to add new users to a default group is no longer working. The result is that users who already exist on the machine when the workspace is created are added to certain default groups (e.g. jupyterhub), but new users in the CO are not.

This PR addresses this issue by creating a cronjob that adds regular users to a group. Runs every 5 minutes.